### PR TITLE
Logo: improved ASCII banner + standard default

### DIFF
--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -47,6 +47,7 @@ paste_blocklist:
   - iTerm2
   - com.apple.Terminal
   - com.googlecode.iterm2
+show_logo: true
 ```
 
 ## 5) 動作確認（ダミー）

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,6 +45,7 @@ paste_blocklist:
   - iTerm2
   - com.apple.Terminal
   - com.googlecode.iterm2
+show_logo: true
 ```
 
 ## 5) Quick Check (Simulated)
@@ -83,4 +84,3 @@ Type `p` + Enter to press, `r` + Enter to release, `q` to quit.
 - `PT_PASTE_GUARD`, `PT_PASTE_BLOCKLIST`
 
 Note: Docker is not supported for runtime (device/GUI constraints).
-

--- a/presstalk.yaml
+++ b/presstalk.yaml
@@ -26,5 +26,5 @@ paste_blocklist:     # names or bundle IDs (case‑insensitive substring match)
   - iTerm2
   - com.apple.Terminal
   - com.googlecode.iterm2
-\n+# UI
 show_logo: true
+logo_style: standard  # standard (ASCII art) or simple

--- a/presstalk.yaml
+++ b/presstalk.yaml
@@ -26,3 +26,5 @@ paste_blocklist:     # names or bundle IDs (case‑insensitive substring match)
   - iTerm2
   - com.apple.Terminal
   - com.googlecode.iterm2
+\n+# UI
+show_logo: true

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -148,7 +148,7 @@ def main():
         cfg = Config(config_path=cfg_path)
         # banner
         if getattr(cfg, 'show_logo', True):
-            print_logo(use_color=True)
+            print_logo(use_color=True, style=getattr(cfg, 'logo_style', 'simple'))
         bps = cfg.bytes_per_second
         pre_bytes = int(bps * (cfg.prebuffer_ms / 1000.0))
         ring = RingBuffer(max(1, pre_bytes or 1))
@@ -173,7 +173,7 @@ def main():
         cfg = Config(config_path=cfg_path)
         # banner
         if getattr(cfg, 'show_logo', True):
-            print_logo(use_color=True)
+            print_logo(use_color=True, style=getattr(cfg, 'logo_style', 'simple'))
         if args.language:
             cfg.language = args.language
         if args.model:

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import time
+import os
 
 from .config import Config
 from .ring_buffer import RingBuffer

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -9,6 +9,7 @@ from .orchestrator import Orchestrator
 from .paste_macos import insert_text
 from .engine.dummy_engine import DummyAsrEngine
 from .logger import get_logger, Logger, QUIET, INFO, DEBUG
+from .logo import print_logo
 
 
 def _build_run_orchestrator(cfg: Config) -> Orchestrator:
@@ -144,6 +145,9 @@ def main():
         if not cfg_path and os.path.isfile("presstalk.yaml"):
             cfg_path = "presstalk.yaml"
         cfg = Config(config_path=cfg_path)
+        # banner
+        if getattr(cfg, 'show_logo', True):
+            print_logo(use_color=True)
         bps = cfg.bytes_per_second
         pre_bytes = int(bps * (cfg.prebuffer_ms / 1000.0))
         ring = RingBuffer(max(1, pre_bytes or 1))
@@ -166,6 +170,9 @@ def main():
         if not cfg_path and os.path.isfile("presstalk.yaml"):
             cfg_path = "presstalk.yaml"
         cfg = Config(config_path=cfg_path)
+        # banner
+        if getattr(cfg, 'show_logo', True):
+            print_logo(use_color=True)
         if args.language:
             cfg.language = args.language
         if args.model:

--- a/src/presstalk/config.py
+++ b/src/presstalk/config.py
@@ -23,6 +23,8 @@ class Config:
     # Paste
     paste_guard: Optional[bool] = None
     paste_blocklist: Optional[Any] = None
+    # UI misc
+    show_logo: Optional[bool] = None
     # Source
     config_path: Optional[str] = None
 
@@ -39,6 +41,7 @@ class Config:
         hk = "ctrl"
         pguard = True
         pblock = "Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2"
+        slog = True
         # overlay YAML
         if data:
             lang = data.get("language", lang)
@@ -56,6 +59,11 @@ class Config:
                     pass
             if "paste_blocklist" in data:
                 pblock = data.get("paste_blocklist", pblock)
+            if "show_logo" in data:
+                try:
+                    slog = bool(data.get("show_logo"))
+                except Exception:
+                    pass
         # overlay ENV
         lang = os.getenv("PT_LANGUAGE", lang)
         sr = int(os.getenv("PT_SAMPLE_RATE", str(sr)))
@@ -68,6 +76,10 @@ class Config:
         if env_guard is not None:
             pguard = env_guard not in ("0", "false", "False")
         pblock = os.getenv("PT_PASTE_BLOCKLIST", pblock)
+        env_logo = os.getenv("PT_NO_LOGO")
+        if env_logo is not None:
+            # PT_NO_LOGO=1 disables logo
+            slog = False if env_logo not in ("0", "false", "False") else slog
         # assign with explicit overrides last
         self.language = self.language or lang
         self.sample_rate = int(self.sample_rate or sr)
@@ -83,6 +95,8 @@ class Config:
             self.paste_guard = pguard
         if self.paste_blocklist is None:
             self.paste_blocklist = pblock
+        if self.show_logo is None:
+            self.show_logo = slog
 
     @property
     def bytes_per_second(self) -> int:

--- a/src/presstalk/config.py
+++ b/src/presstalk/config.py
@@ -25,6 +25,7 @@ class Config:
     paste_blocklist: Optional[Any] = None
     # UI misc
     show_logo: Optional[bool] = None
+    logo_style: Optional[str] = None  # 'simple' (default) or 'standard'
     # Source
     config_path: Optional[str] = None
 
@@ -42,6 +43,7 @@ class Config:
         pguard = True
         pblock = "Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2"
         slog = True
+        lstyle = "standard"
         # overlay YAML
         if data:
             lang = data.get("language", lang)
@@ -64,6 +66,11 @@ class Config:
                     slog = bool(data.get("show_logo"))
                 except Exception:
                     pass
+            if "logo_style" in data:
+                try:
+                    lstyle = str(data.get("logo_style")) or lstyle
+                except Exception:
+                    pass
         # overlay ENV
         lang = os.getenv("PT_LANGUAGE", lang)
         sr = int(os.getenv("PT_SAMPLE_RATE", str(sr)))
@@ -80,6 +87,9 @@ class Config:
         if env_logo is not None:
             # PT_NO_LOGO=1 disables logo
             slog = False if env_logo not in ("0", "false", "False") else slog
+        env_style = os.getenv("PT_LOGO_STYLE")
+        if env_style:
+            lstyle = env_style
         # assign with explicit overrides last
         self.language = self.language or lang
         self.sample_rate = int(self.sample_rate or sr)
@@ -97,6 +107,8 @@ class Config:
             self.paste_blocklist = pblock
         if self.show_logo is None:
             self.show_logo = slog
+        if self.logo_style is None:
+            self.logo_style = lstyle
 
     @property
     def bytes_per_second(self) -> int:

--- a/src/presstalk/logo.py
+++ b/src/presstalk/logo.py
@@ -1,0 +1,34 @@
+ANSI_RESET = "\x1b[0m"
+ANSI_BOLD = "\x1b[1m"
+ANSI_CYAN = "\x1b[36m"
+ANSI_MAGENTA = "\x1b[35m"
+
+
+def render_logo(color: bool = True) -> str:
+    # Simple ASCII logo for "PressTalk"
+    art = [
+        r"  ____                 _____     _ _   ",
+        r" |  _ \ _ __ ___  ___ |_   _|__ | | |__  ",
+        r" | |_) | '__/ _ \/ __|  | |/ _ \| | '_ \ ",
+        r" |  __/| | | (_) \__ \  | | (_) | | | | |",
+        r" |_|   |_|  \___/|___/  |_|\___/|_|_| |_|",
+    ]
+    title = " PressTalk"
+    if not color:
+        return "\n".join(art + [title])
+    # Apply simple two-tone gradient
+    c1, c2 = ANSI_CYAN, ANSI_MAGENTA
+    lines = []
+    for i, ln in enumerate(art):
+        c = c1 if i % 2 == 0 else c2
+        lines.append(f"{c}{ANSI_BOLD}{ln}{ANSI_RESET}")
+    lines.append(f"{ANSI_BOLD}{title}{ANSI_RESET}")
+    return "\n".join(lines)
+
+
+def print_logo(use_color: bool = True) -> None:
+    try:
+        print(render_logo(color=use_color))
+    except Exception:
+        pass
+

--- a/src/presstalk/logo.py
+++ b/src/presstalk/logo.py
@@ -28,7 +28,8 @@ def render_logo(color: bool = True) -> str:
 
 def print_logo(use_color: bool = True) -> None:
     try:
+        # Print logo followed by a blank line for spacing
         print(render_logo(color=use_color))
+        print()
     except Exception:
         pass
-

--- a/src/presstalk/logo.py
+++ b/src/presstalk/logo.py
@@ -2,34 +2,50 @@ ANSI_RESET = "\x1b[0m"
 ANSI_BOLD = "\x1b[1m"
 ANSI_CYAN = "\x1b[36m"
 ANSI_MAGENTA = "\x1b[35m"
+ANSI_WHITE = "\x1b[37m"
 
 
-def render_logo(color: bool = True) -> str:
-    # Simple ASCII logo for "PressTalk"
-    art = [
-        r"  ____                 _____     _ _   ",
-        r" |  _ \ _ __ ___  ___ |_   _|__ | | |__  ",
-        r" | |_) | '__/ _ \/ __|  | |/ _ \| | '_ \ ",
-        r" |  __/| | | (_) \__ \  | | (_) | | | | |",
-        r" |_|   |_|  \___/|___/  |_|\___/|_|_| |_|",
-    ]
-    title = " PressTalk"
+def render_logo(color: bool = True, style: str = "simple") -> str:
+    """Render the PressTalk logo.
+    style: 'simple' (clear text) or 'standard' (ASCII art)
+    """
+    if style == "standard":
+        # Clearer figlet-style ASCII for "PressTalk"
+        art = [
+            r"  ____                 _____         _ _    ",
+            r" |  _ \ _ __ ___  ___ |_   _|__  ___| | | __",
+            r" | |_) | '__/ _ \/ _ \  | |/ _ \/ __| | |/ /",
+            r" |  __/| | |  __/  __/  | |  __/\__ \ |   < ",
+            r" |_|   |_|  \___|\___|  |_|\___||___/_|_|\_\",
+        ]
+        title = "   PressTalk"
+        if not color:
+            return "\n".join(art + [title])
+        c1, c2 = ANSI_CYAN, ANSI_MAGENTA
+        lines = []
+        for i, ln in enumerate(art):
+            c = c1 if i % 2 == 0 else c2
+            lines.append(f"{c}{ANSI_BOLD}{ln}{ANSI_RESET}")
+        # Add a clear wordmark under the ASCII art for readability
+        word = "PressTalk"
+        underline = "=" * len(word)
+        lines.append(f"{ANSI_BOLD}{title}{ANSI_RESET}")
+        lines.append(f"{ANSI_BOLD}{ANSI_MAGENTA}{word}{ANSI_RESET}")
+        lines.append(f"{ANSI_WHITE}{underline}{ANSI_RESET}")
+        return "\n".join(lines)
+
+    # simple style (default): clear, unambiguous wordmark
+    word = "PressTalk"
+    underline = "=" * len(word)
     if not color:
-        return "\n".join(art + [title])
-    # Apply simple two-tone gradient
-    c1, c2 = ANSI_CYAN, ANSI_MAGENTA
-    lines = []
-    for i, ln in enumerate(art):
-        c = c1 if i % 2 == 0 else c2
-        lines.append(f"{c}{ANSI_BOLD}{ln}{ANSI_RESET}")
-    lines.append(f"{ANSI_BOLD}{title}{ANSI_RESET}")
-    return "\n".join(lines)
+        return f"{word}\n{underline}"
+    return f"{ANSI_BOLD}{ANSI_MAGENTA}{word}{ANSI_RESET}\n{ANSI_WHITE}{underline}{ANSI_RESET}"
 
 
-def print_logo(use_color: bool = True) -> None:
+def print_logo(use_color: bool = True, style: str = "simple") -> None:
     try:
         # Print logo followed by a blank line for spacing
-        print(render_logo(color=use_color))
+        print(render_logo(color=use_color, style=style))
         print()
     except Exception:
         pass

--- a/src/presstalk/logo.py
+++ b/src/presstalk/logo.py
@@ -12,24 +12,25 @@ def render_logo(color: bool = True, style: str = "simple") -> str:
     if style == "standard":
         # Clearer figlet-style ASCII for "PressTalk"
         art = [
-            r"  ____                 _____         _ _    ",
-            r" |  _ \ _ __ ___  ___ |_   _|__  ___| | | __",
-            r" | |_) | '__/ _ \/ _ \  | |/ _ \/ __| | |/ /",
-            r" |  __/| | |  __/  __/  | |  __/\__ \ |   < ",
-            r" |_|   |_|  \___|\___|  |_|\___||___/_|_|\_\",
+            r" ____                   _____     _ _    ",
+            r"|  _ \ _ __ ___  ___ __|_   _|_ _| | | __",
+            r"| |_) | '__/ _ \/ __/ __|| |/ _` | | |/ /",
+            r"|  __/| | |  __/\__ \__ \| | (_| | |   < ",
+            r"|_|   |_|  \___||___/___/|_|\__,_|_|_|\_\\",
         ]
-        title = "   PressTalk"
         if not color:
-            return "\n".join(art + [title])
+            # ASCII art + single plain wordmark
+            word = "PressTalk"
+            underline = "=" * len(word)
+            return "\n".join(art + [word, underline])
         c1, c2 = ANSI_CYAN, ANSI_MAGENTA
         lines = []
         for i, ln in enumerate(art):
             c = c1 if i % 2 == 0 else c2
             lines.append(f"{c}{ANSI_BOLD}{ln}{ANSI_RESET}")
-        # Add a clear wordmark under the ASCII art for readability
+        # Add a clear wordmark under the ASCII art for readability (single occurrence)
         word = "PressTalk"
         underline = "=" * len(word)
-        lines.append(f"{ANSI_BOLD}{title}{ANSI_RESET}")
         lines.append(f"{ANSI_BOLD}{ANSI_MAGENTA}{word}{ANSI_RESET}")
         lines.append(f"{ANSI_WHITE}{underline}{ANSI_RESET}")
         return "\n".join(lines)


### PR DESCRIPTION
This PR updates the startup logo: fixes spelling, adds a single wordmark underline for readability, restores default logo style to 'standard' (ASCII art), adds YAML option 'logo_style', and prints a blank line after the banner. Includes the earlier YAML/config/CLI changes already on develop.