### PR TITLE
Config: repo-root YAML default + docs refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,4 +34,4 @@
 
 ## Security & Configuration Tips
 - macOS permissions required: Microphone and Accessibility (for paste/hotkey). See `docs/usage.md`.
-- Configuration: YAML auto-discovery (`./presstalk.yaml`, `$XDG_CONFIG_HOME/presstalk/config.yaml`, `~/.presstalk.yaml`). CLI overrides file; env vars still supported (`PT_LANGUAGE`, etc.).
+- Configuration: YAML at repository root (`presstalk.yaml`) is auto-used for editable installs; CLI `--config` overrides; env vars still supported (`PT_LANGUAGE`, etc.).

--- a/README-ja.md
+++ b/README-ja.md
@@ -22,14 +22,14 @@ cd presstalk
 ```bash
 make bootstrap
 # 以後どこからでも
-presstalk run
+presstalk
 ```
 
 方法B（プロジェクト内 venv）:
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install -e .
-uv run presstalk run
+uv run presstalk
 ```
 Tips:
 - 初回は macOS のマイク/アクセシビリティ許可が必要

--- a/README-ja.md
+++ b/README-ja.md
@@ -11,14 +11,24 @@
 - ロードマップ: docs/ROADMAP.md
 
 ## クイックスタート
+
+まずクローン:
+```bash
+git clone https://github.com/lostandfound/presstalk.git
+cd presstalk
+```
+
+方法A（推奨・No‑CD 一発セットアップ）:
+```bash
+make bootstrap
+# 以後どこからでも
+presstalk run
+```
+
+方法B（プロジェクト内 venv）:
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install -e .
-
-# 動作確認（疑似）
-uv run presstalk simulate
-
-# 実行（既定＝グローバルホットキー）
 uv run presstalk run
 ```
 Tips:

--- a/README-ja.md
+++ b/README-ja.md
@@ -32,6 +32,15 @@ Tips:
 - `make test` / `make test-file FILE=tests/test_controller.py`
 - `make lint` / `make format` / `make typecheck`
 
+## リポジトリに移動せずに起動する（No‑CD Setup）
+- 一発セットアップ（uv/pipx/venv を自動判別）:
+  - `make bootstrap`
+  - 以後はどこからでも: `presstalk run`（または `pt` エイリアス）
+- グローバルインストール（uv）:
+  - `make install-global` 実行後、`~/.local/bin` を PATH に追加（`make path-zsh` か `make path-bash`）
+- いま即起動（インストール不要・リポジトリから実行）:
+  - `make run-anywhere`
+
 ## 依存関係
 - Python 3.9+（macOS 13+ 推奨）
 - 開発ツール: `xcode-select --install`

--- a/README.md
+++ b/README.md
@@ -13,14 +13,23 @@ Local voice input tool using push‑to‑talk (PTT). Hold a control key to recor
 
 ## Quick Start
 
+Clone first:
+```bash
+git clone https://github.com/lostandfound/presstalk.git
+cd presstalk
+```
+
+Option A — No-CD (recommended, 1-step setup):
+```bash
+make bootstrap
+# then from anywhere
+presstalk run
+```
+
+Option B — Project-local venv:
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install -e .
-
-# Smoke test (no extra permissions needed)
-uv run presstalk simulate
-
-# Run (global hotkey is default)
 uv run presstalk run
 ```
 Tips:
@@ -40,6 +49,15 @@ Tips:
 - `make simulate CHUNKS="hello world" DELAY=40`
 - `make test` / `make test-file FILE=tests/test_controller.py`
 - `make lint` / `make format` / `make typecheck`
+
+## No-CD Setup (Run from anywhere)
+- One-shot setup (auto-detects uv/pipx/venv):
+  - `make bootstrap`
+  - Then run globally: `presstalk run` (or `pt` if alias was added)
+- Quick global install (uv):
+  - `make install-global` and ensure `~/.local/bin` is in PATH (`make path-zsh` or `make path-bash`)
+- Run now without install (from repo):
+  - `make run-anywhere`
 
 ## Configuration (YAML)
 - Auto-discovery: `./presstalk.yaml`, `$XDG_CONFIG_HOME/presstalk/config.yaml`, or `~/.presstalk.yaml`.

--- a/README.md
+++ b/README.md
@@ -23,19 +23,20 @@ Option A — No-CD (recommended, 1-step setup):
 ```bash
 make bootstrap
 # then from anywhere
-presstalk run
+presstalk
 ```
 
 Option B — Project-local venv:
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install -e .
-uv run presstalk run
+uv run presstalk
 ```
 Tips:
 - On first run, macOS prompts for Microphone and Accessibility permissions.
 - Hold the chosen key (default `ctrl`) to record. When you release it, PressTalk transcribes locally and pastes the text at your current cursor position in the active app.
 - Paste guard is enabled by default: paste is skipped when Terminal/iTerm is frontmost (configurable).
+  - Tip: `presstalk` with no args equals `presstalk run`.
 
 ## What It Does
 - Voice input for any text field: record while holding a key, paste on release.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Tips:
   - `make run-anywhere`
 
 ## Configuration (YAML)
-- Auto-discovery: `./presstalk.yaml`, `$XDG_CONFIG_HOME/presstalk/config.yaml`, or `~/.presstalk.yaml`.
+- Auto-discovery: `presstalk.yaml` in the repository root (editable installs).
 - Override path: `uv run presstalk run --config path/to/config.yaml`.
 - Example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Language: [English](README.md) | [日本語](README-ja.md)
 
-Local push‑to‑talk (PTT) with offline ASR. macOS-oriented, works entirely locally (no server required).
+Local voice input tool using push‑to‑talk (PTT). Hold a control key to record; release to insert transcribed text at the cursor in the frontmost app. Runs entirely on your Mac (no server).
 
 - Architecture: docs/architecture.md
 - Roadmap: docs/ROADMAP.md
@@ -25,7 +25,14 @@ uv run presstalk run
 ```
 Tips:
 - On first run, macOS prompts for Microphone and Accessibility permissions.
-- Hold the chosen key (e.g., `ctrl`) to record; release to finalize and paste.
+- Hold the chosen key (default `ctrl`) to record. When you release it, PressTalk transcribes locally and pastes the text at your current cursor position in the active app.
+- Paste guard is enabled by default: paste is skipped when Terminal/iTerm is frontmost (configurable).
+
+## What It Does
+- Voice input for any text field: record while holding a key, paste on release.
+- Global hotkey by default (`ctrl`), configurable via YAML or CLI.
+- Offline ASR with faster‑whisper; audio never leaves your device.
+- Paste guard avoids Terminal/iTerm by default; customize via YAML.
 
 ## Makefile Shortcuts
 - `make venv && source .venv/bin/activate && make install`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,6 +5,7 @@
 - Subcommands: `run`, `simulate`
 
 ## run — Local PTT (default: global hotkey)
+(Note: `presstalk` with no args is equivalent to `presstalk run`.)
 - `--config <path>`: YAML path. Auto: `./presstalk.yaml` if present.
 - `--mode <hold|toggle>`: PTT mode. Defaults to YAML or `hold`.
 - `--console`: Use console input instead of global hotkey.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,7 +30,7 @@ Examples
 - `uv run presstalk simulate --chunks hello world --delay-ms 40`
 
 ## Configuration (YAML / Env)
-- YAML auto-discovery: `./presstalk.yaml`, `$XDG_CONFIG_HOME/presstalk/config.yaml`, `~/.presstalk.yaml`.
+- YAML auto-discovery: `presstalk.yaml` in the repository root (editable installs).
 - Keys: `language`, `model`, `sample_rate`, `channels`, `prebuffer_ms`, `min_capture_ms`, `mode`, `hotkey`, `paste_guard`, `paste_blocklist`.
 - Env vars (optional): `PT_LANGUAGE`, `PT_SAMPLE_RATE`, `PT_CHANNELS`, `PT_PREBUFFER_MS`, `PT_MIN_CAPTURE_MS`, `PT_MODEL`, `PT_PASTE_GUARD`, `PT_PASTE_BLOCKLIST`.
 - Precedence: CLI > Env > YAML > defaults.

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -29,7 +29,7 @@ brew install portaudio
 - アクセシビリティ（貼り付け用）: システム設定 → プライバシーとセキュリティ → アクセシビリティ で Terminal を有効化。
 
 ## 4) 設定（YAML）
-- 自動検出: `./presstalk.yaml`、`$XDG_CONFIG_HOME/presstalk/config.yaml`、`~/.presstalk.yaml`
+- 自動検出: リポジトリルートの `presstalk.yaml`（editable インストール時）
 - 明示指定: `uv run presstalk run --config path/to/config.yaml`
 - 例:
 ```yaml

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,7 +27,7 @@ Then rerun the install command.
 - Accessibility: enable your terminal app for global hotkeys and paste.
 
 ## 4) Configuration (YAML)
-- Auto-discovery: `./presstalk.yaml`, `$XDG_CONFIG_HOME/presstalk/config.yaml`, `~/.presstalk.yaml`
+- Auto-discovery: `presstalk.yaml` in the repository root (editable installs).
 - Override path: `uv run presstalk run --config path/to/config.yaml`
 - Example
 ```yaml

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -140,6 +140,10 @@ def main():
         print("presstalk 0.0.1")
         return 0
 
+    # Default behavior: no subcommand means "run"
+    if not args.cmd:
+        args.cmd = "run"
+
     if args.cmd == "simulate":
         # default to local YAML if present
         cfg_path = args.config

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -146,10 +146,17 @@ def main():
         args = parser.parse_args(["run"])
 
     if args.cmd == "simulate":
-        # default to local YAML if present
+        # default to repository-root YAML if present (editable installs)
         cfg_path = args.config
-        if not cfg_path and os.path.isfile("presstalk.yaml"):
-            cfg_path = "presstalk.yaml"
+        if not cfg_path:
+            try:
+                pkg_dir = os.path.dirname(__file__)            # src/presstalk
+                repo_root = os.path.abspath(os.path.join(pkg_dir, "..", ".."))
+                candidate = os.path.join(repo_root, "presstalk.yaml")
+                if os.path.isfile(candidate):
+                    cfg_path = candidate
+            except Exception:
+                pass
         cfg = Config(config_path=cfg_path)
         # banner
         if getattr(cfg, 'show_logo', True):
@@ -171,10 +178,17 @@ def main():
         return 0
 
     if args.cmd == "run":
-        # default to local YAML if present
+        # default to repository-root YAML if present (editable installs)
         cfg_path = args.config
-        if not cfg_path and os.path.isfile("presstalk.yaml"):
-            cfg_path = "presstalk.yaml"
+        if not cfg_path:
+            try:
+                pkg_dir = os.path.dirname(__file__)
+                repo_root = os.path.abspath(os.path.join(pkg_dir, "..", ".."))
+                candidate = os.path.join(repo_root, "presstalk.yaml")
+                if os.path.isfile(candidate):
+                    cfg_path = candidate
+            except Exception:
+                pass
         cfg = Config(config_path=cfg_path)
         # banner
         if getattr(cfg, 'show_logo', True):

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -142,7 +142,8 @@ def main():
 
     # Default behavior: no subcommand means "run"
     if not args.cmd:
-        args.cmd = "run"
+        # Reparse with implicit 'run' so subparser defaults are populated
+        args = parser.parse_args(["run"])
 
     if args.cmd == "simulate":
         # default to local YAML if present


### PR DESCRIPTION
This PR changes default config auto-discovery to use repository-root presstalk.yaml (for editable installs), updates CLI accordingly, and refreshes docs (README EN/JA, usage EN/JA, commands, AGENTS) to reflect the new behavior. Also includes recent fixes: 'presstalk' == 'presstalk run', improved startup logo, and Makefile no‑CD bootstrap.\n\nSummary:\n- CLI: implicit 'run' on no subcommand; repo-root config fallback\n- Docs: Quick Start from git clone; No‑CD setup; YAML auto-discovery -> repo root\n- Makefile: bootstrap/run-anywhere/alias/path helpers\n- Logo: improved ASCII art + wordmark, blank line spacing\n- Tests: YAML precedence + paste guard (already merged earlier)