### PR TITLE
feat: Windows paste backend and cross-platform dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 # Virtual envs
 .venv/
+
+# Local Claude configuration
+CLAUDE.local.md

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -7,7 +7,7 @@ from .ring_buffer import RingBuffer
 from .controller import Controller
 from .capture import PCMCapture
 from .orchestrator import Orchestrator
-from .paste_macos import insert_text
+from .paste import insert_text
 from .engine.dummy_engine import DummyAsrEngine
 from .logger import get_logger, Logger, QUIET, INFO, DEBUG
 from .logo import print_logo

--- a/src/presstalk/paste.py
+++ b/src/presstalk/paste.py
@@ -1,0 +1,9 @@
+import sys
+
+if sys.platform == "darwin":
+    from .paste_macos import insert_text  # noqa: F401
+elif sys.platform == "win32":
+    from .paste_windows import insert_text  # noqa: F401
+else:
+    # Fallback: import macOS variant; callers can supply stubs in tests
+    from .paste_macos import insert_text  # type: ignore # noqa: F401

--- a/src/presstalk/paste_windows.py
+++ b/src/presstalk/paste_windows.py
@@ -1,0 +1,113 @@
+import os
+import subprocess
+import ctypes
+from ctypes import wintypes
+from typing import Callable, Optional, Tuple, Dict, Sequence, Union
+
+
+def _get_frontmost_app(*, runner: Optional[Callable[[list], Tuple[int, str]]] = None) -> Dict[str, str]:
+    """Return {'name': ...} of the foreground process on Windows or empty dict on failure.
+
+    runner is unused on Windows implementation but kept for signature parity/testing.
+    """
+    try:
+        user32 = ctypes.windll.user32  # type: ignore[attr-defined]
+        GetForegroundWindow = user32.GetForegroundWindow
+        GetWindowThreadProcessId = user32.GetWindowThreadProcessId
+        GetForegroundWindow.restype = wintypes.HWND
+        GetWindowThreadProcessId.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.DWORD)]
+        hwnd = GetForegroundWindow()
+        pid = wintypes.DWORD(0)
+        GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+        try:
+            out = subprocess.check_output(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    f"(Get-Process -Id {pid.value}).ProcessName",
+                ],
+                text=True,
+                timeout=1,
+            ).strip()
+        except Exception:
+            out = ""
+        return {k: v for k, v in {"name": out}.items() if v}
+    except Exception:
+        return {}
+
+
+def insert_text(
+    text: str,
+    *,
+    run_cmd: Optional[Callable[[list], int]] = None,
+    frontmost_getter: Optional[Callable[[], Dict[str, str]]] = None,
+    guard_enabled: Optional[bool] = None,
+    blocklist: Optional[Union[str, Sequence[str]]] = None,
+    clipboard_fn: Optional[Callable[[str], bool]] = None,
+) -> bool:
+    """Insert text at current cursor by clipboard swap + Ctrl+V (Windows).
+
+    - If guard is enabled, block paste when foreground process matches blocklist.
+    - `run_cmd` (if provided) is called instead of sending keys via pynput; it should
+      return 0 on success.
+    - `clipboard_fn` (if provided) is used to set clipboard; otherwise `clip.exe`.
+    """
+    if text is None:
+        return True
+
+    # Paste guard
+    guard = guard_enabled if guard_enabled is not None else (
+        os.getenv("PT_PASTE_GUARD", "1") not in ("0", "false", "False")
+    )
+    if guard:
+        try:
+            fg = frontmost_getter() if frontmost_getter else _get_frontmost_app()
+        except Exception:
+            fg = {}
+        if fg:
+            name = (fg.get("name") or "").lower()
+            if blocklist is None:
+                block_env = os.getenv(
+                    "PT_PASTE_BLOCKLIST",
+                    "cmd.exe,powershell.exe,pwsh.exe,WindowsTerminal.exe,wt.exe,conhost.exe",
+                )
+                blocks = [s.strip().lower() for s in block_env.split(",") if s.strip()]
+            else:
+                if isinstance(blocklist, str):
+                    blocks = [s.strip().lower() for s in blocklist.split(",") if s.strip()]
+                else:
+                    blocks = [str(s).strip().lower() for s in blocklist if str(s).strip()]
+            if any(b and (name.find(b) != -1) for b in blocks):
+                return False
+
+    # Clipboard
+    if clipboard_fn is not None:
+        try:
+            if not clipboard_fn(text):
+                return False
+        except Exception:
+            return False
+    else:
+        try:
+            p = subprocess.Popen(["clip"], stdin=subprocess.PIPE, text=True)
+            p.communicate(text, timeout=1)
+        except Exception:
+            return False
+
+    # Key send: Ctrl+V
+    if run_cmd is not None:
+        try:
+            return run_cmd(["ctrl+v"]) == 0
+        except Exception:
+            return False
+
+    try:
+        from pynput import keyboard  # type: ignore
+        kb = keyboard.Controller()
+        with kb.pressed(keyboard.Key.ctrl):
+            kb.press('v')
+            kb.release('v')
+        return True
+    except Exception:
+        return False

--- a/tests/test_paste_windows.py
+++ b/tests/test_paste_windows.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from presstalk.paste_windows import insert_text  # type: ignore
+
+
+class TestPasteWindows(unittest.TestCase):
+    def test_insert_text_with_stub_runner_and_clipboard(self):
+        calls = {"run": 0, "clip": 0}
+
+        def runner(cmd):
+            calls["run"] += 1
+            return 0
+
+        def clipboard_fn(text: str) -> bool:
+            calls["clip"] += 1
+            return True
+
+        ok = insert_text("hello", run_cmd=runner, clipboard_fn=clipboard_fn)
+        self.assertTrue(ok)
+        self.assertEqual(calls["clip"], 1)
+        self.assertEqual(calls["run"], 1)
+
+    def test_insert_none_returns_true(self):
+        self.assertTrue(insert_text(None, run_cmd=lambda _: 0, clipboard_fn=lambda t: True))
+
+    def test_paste_guard_blocks_terminal(self):
+        calls = {"run": 0, "clip": 0}
+
+        def runner(_cmd):
+            calls["run"] += 1
+            return 0
+
+        def clipboard_fn(text: str) -> bool:
+            calls["clip"] += 1
+            return True
+
+        def fg():
+            return {"name": "WindowsTerminal.exe"}
+
+        ok = insert_text("hello", run_cmd=runner, frontmost_getter=fg, clipboard_fn=clipboard_fn)
+        self.assertFalse(ok)
+        self.assertEqual(calls["run"], 0)
+        self.assertEqual(calls["clip"], 0)
+
+    def test_paste_guard_allows_notepad(self):
+        calls = {"run": 0, "clip": 0}
+
+        def runner(_cmd):
+            calls["run"] += 1
+            return 0
+
+        def clipboard_fn(text: str) -> bool:
+            calls["clip"] += 1
+            return True
+
+        def fg():
+            return {"name": "notepad.exe"}
+
+        ok = insert_text("hello", run_cmd=runner, frontmost_getter=fg, clipboard_fn=clipboard_fn)
+        self.assertTrue(ok)
+        self.assertEqual(calls["run"], 1)
+        self.assertEqual(calls["clip"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Windows paste (`insert_text`) with clipboard via `clip.exe` and key send via `pynput` (Ctrl+V), and introduces a cross-platform `presstalk.paste` dispatcher. CLI now imports from the dispatcher.

## Changes
- New `src/presstalk/paste_windows.py`
- New `src/presstalk/paste.py` (platform dispatch)
- `src/presstalk/cli.py` import updated to use dispatcher
- New unit tests: `tests/test_paste_windows.py`

## Test plan
- Unit tests with dependency injection for clipboard/frontmost/runner stubs
- `uv run python -m unittest -v` (CI not configured)

## Notes
- macOS behavior unchanged; Windows gains paste guard and insertion path.

Fixes #6