### PR TITLE
config/docs: OS-specific default paste guard blocklist (issue #8)

### DIFF
--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -112,3 +112,6 @@ uv run presstalk run --mode hold --hotkey ctrl --language ja --model small --pre
   - `PT_PASTE_GUARD=1`（既定1=有効、0で無効）
   - `PT_PASTE_BLOCKLIST="Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2"`
     - アプリ名/Bundle ID の部分一致で判定（カンマ区切りで追加可能）
+  - 既定ブロックリスト（OS別）:
+    - macOS: `Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2`
+    - Windows: `cmd.exe,powershell.exe,pwsh.exe,WindowsTerminal.exe,wt.exe,conhost.exe`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,4 +83,9 @@ Type `p` + Enter to press, `r` + Enter to release, `q` to quit.
 - `PT_LANGUAGE`, `PT_SAMPLE_RATE`, `PT_CHANNELS`, `PT_PREBUFFER_MS`, `PT_MIN_CAPTURE_MS`, `PT_MODEL`
 - `PT_PASTE_GUARD`, `PT_PASTE_BLOCKLIST`
 
+### Paste Guard defaults
+- macOS default blocklist: `Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2`
+- Windows default blocklist: `cmd.exe,powershell.exe,pwsh.exe,WindowsTerminal.exe,wt.exe,conhost.exe`
+You can override with YAML `paste_blocklist:` or `PT_PASTE_BLOCKLIST`.
+
 Note: Docker is not supported for runtime (device/GUI constraints).

--- a/src/presstalk/config.py
+++ b/src/presstalk/config.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+import sys
 from typing import Optional, Any, Dict
 
 try:
@@ -41,7 +42,11 @@ class Config:
         mde = "hold"
         hk = "ctrl"
         pguard = True
-        pblock = "Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2"
+        # OS-specific default paste guard blocklist
+        if os.name == 'nt' or sys.platform == 'win32':  # type: ignore[name-defined]
+            pblock = "cmd.exe,powershell.exe,pwsh.exe,WindowsTerminal.exe,wt.exe,conhost.exe"
+        else:
+            pblock = "Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2"
         slog = True
         lstyle = "standard"
         # overlay YAML

--- a/tests/test_paste_guard_defaults.py
+++ b/tests/test_paste_guard_defaults.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from presstalk.config import Config
+
+
+class TestPasteGuardDefaults(unittest.TestCase):
+    def setUp(self):
+        # Ensure env var is not set unless a test sets it
+        os.environ.pop("PT_PASTE_BLOCKLIST", None)
+
+    def tearDown(self):
+        os.environ.pop("PT_PASTE_BLOCKLIST", None)
+
+    def test_macos_default_blocklist(self):
+        real = sys.platform
+        try:
+            sys.platform = 'darwin'
+            cfg = Config()
+            self.assertIsNotNone(cfg.paste_blocklist)
+            bl = cfg.paste_blocklist
+            if isinstance(bl, str):
+                bl = [s.strip().lower() for s in bl.split(',') if s.strip()]
+            self.assertIn('terminal', ''.join(bl))
+            # ensure typical mac key is present
+            joined = ','.join(bl)
+            self.assertIn('com.apple.terminal', joined)
+        finally:
+            sys.platform = real
+
+    def test_windows_default_blocklist(self):
+        real = sys.platform
+        try:
+            sys.platform = 'win32'
+            cfg = Config()
+            bl = cfg.paste_blocklist
+            if isinstance(bl, str):
+                bl = [s.strip().lower() for s in bl.split(',') if s.strip()]
+            joined = ','.join(bl)
+            self.assertIn('windowsterminal.exe', joined)
+            self.assertIn('powershell.exe', joined)
+        finally:
+            sys.platform = real
+
+    def test_env_overrides_defaults_always(self):
+        real = sys.platform
+        try:
+            sys.platform = 'win32'
+            os.environ['PT_PASTE_BLOCKLIST'] = 'foo,bar'
+            cfg = Config()
+            bl = cfg.paste_blocklist
+            if isinstance(bl, str):
+                bl = [s.strip().lower() for s in bl.split(',') if s.strip()]
+            self.assertEqual(bl, ['foo', 'bar'])
+        finally:
+            os.environ.pop('PT_PASTE_BLOCKLIST', None)
+            sys.platform = real
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Introduce OS-specific defaults for the paste guard blocklist and document them.

## Changes
- Config: macOS default unchanged; Windows default added
- Docs: usage (EN/JA) updated with defaults and override guidance

## Test plan
- New tests: `tests/test_paste_guard_defaults.py`
- `uv run python -m unittest tests/test_paste_guard_defaults.py -v`

Fixes #8