### PR TITLE
docs: Windows usage notes, paste dispatch in architecture, README updates (issue #9)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -5,7 +5,7 @@
 
 言語: [English](README.md) | [日本語](README-ja.md)
 
-音声入力ツール（プッシュトゥトーク, PTT）。コントロールキーを押している間だけ録音し、離すと最前面アプリのカーソル位置に文字起こし結果を貼り付けます。すべてローカルで動作します（サーバ不要）。
+音声入力ツール（プッシュトゥトーク, PTT）。コントロールキーを押している間だけ録音し、離すと最前面アプリのカーソル位置に文字起こし結果を貼り付けます。すべてローカルで動作します（サーバ不要）。macOS と Windows をサポートします。
 
 - アーキテクチャ: docs/architecture.md
 - 使い方（日本語）: docs/usage-ja.md
@@ -62,9 +62,10 @@ Tips:
   - `make run-anywhere`
 
 ## 依存関係
-- Python 3.9+（macOS 13+ 推奨）
-- 開発ツール: `xcode-select --install`
-- `sounddevice` で失敗する場合: `brew install portaudio` → 再インストール
+- Python 3.9+（macOS 13+ または Windows 10/11）
+- 開発ツール（macOS）: `xcode-select --install`
+- オーディオ（macOSで `sounddevice` が失敗する場合）: `brew install portaudio` → 再インストール
+- 権限: macOS はマイク+アクセシビリティ、Windows は前面アプリのテキスト入力フォーカスが必要
 - 注意: Docker 実行は非対応（マイク/ホットキー/貼り付けの制約）
 
 ## 設定（YAML）
@@ -89,3 +90,5 @@ paste_blocklist:
 ```
 
 ライセンス: MIT（pyproject を参照）
+
+Windows の注意事項やペーストガードの既定値は `docs/usage.md` / `docs/usage-ja.md` を参照してください。

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Language: [English](README.md) | [日本語](README-ja.md)
 
-Local voice input tool using push‑to‑talk (PTT). Hold a control key to record; release to insert transcribed text at the cursor in the frontmost app. Runs entirely on your Mac (no server).
+Local voice input tool using push‑to‑talk (PTT). Hold a control key to record; release to insert transcribed text at the cursor in the frontmost app. Runs entirely on your machine (no server). macOS and Windows are supported.
 
 - Architecture: docs/architecture.md
 - Roadmap: docs/ROADMAP.md
@@ -107,10 +107,10 @@ All runtime dependencies are included by default (pynput, faster-whisper, numpy,
 
 ## Dependencies
 
-- Python 3.9+ on macOS 13+ recommended.
-- Build tools: `xcode-select --install`.
-- Audio backend (only if `sounddevice` build fails): `brew install portaudio`.
-- Permissions: allow Microphone and Accessibility on first run.
+- Python 3.9+ on macOS 13+ or Windows 10/11.
+- Build tools (macOS): `xcode-select --install`.
+- Audio backend (macOS, if `sounddevice` build fails): `brew install portaudio`.
+- Permissions: macOS requires Microphone + Accessibility; Windows requires a focused text input to paste.
 
 Note: Docker is not supported for runtime use (microphone, global hotkeys, and paste require host permissions).
 
@@ -124,4 +124,4 @@ uv run presstalk run \
   --language ja --model small --prebuffer-ms 200 --min-capture-ms 1800
 ```
 
-See docs/usage.md for full instructions and permissions.
+See docs/usage.md for full instructions (including Windows notes) and permissions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,9 @@
 - Engine (`src/presstalk/engine/*`): `FasterWhisperBackend` + `FasterWhisperEngine` implement `AsrEngine` protocol.
 - Controller (`src/presstalk/controller.py`): Press/Release state machine, prebuffer push, live push, and finalize.
 - Orchestrator (`src/presstalk/orchestrator.py`): Coordinates capture lifecycle and pasting.
-- Paste (`src/presstalk/paste_macos.py`): macOS clipboard swap + Cmd+V with paste guard.
+- Paste (`src/presstalk/paste.py`): platform-dispatching `insert_text`.
+  - macOS: `paste_macos.py` (clipboard via pbcopy + Cmd+V via osascript)
+  - Windows: `paste_windows.py` (clipboard via clip.exe + Ctrl+V via pynput)
 
 ## Key Interfaces
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# PressTalk Usage (macOS, Local-Only)
+# PressTalk Usage (macOS/Windows, Local-Only)
 
 ## Prerequisites
 - macOS 13+ (Apple Silicon or Intel)
@@ -79,7 +79,12 @@ Type `p` + Enter to press, `r` + Enter to release, `q` to quit.
 - No paste: check Accessibility permission and text focus in the frontmost app
 - Too short utterances: raise `min_capture_ms` or use small prebuffer
 
-## 9) Environment Variables (optional)
+## 9) Windows Notes
+- Use Windows Terminal for proper ANSI color rendering.
+- Ensure audio devices are working; `sounddevice` uses PortAudio on Windows.
+- Clipboard and paste guard require a focused text input in the foreground app.
+
+## 10) Environment Variables (optional)
 - `PT_LANGUAGE`, `PT_SAMPLE_RATE`, `PT_CHANNELS`, `PT_PREBUFFER_MS`, `PT_MIN_CAPTURE_MS`, `PT_MODEL`
 - `PT_PASTE_GUARD`, `PT_PASTE_BLOCKLIST`
 


### PR DESCRIPTION
## Summary
Add Windows setup/usage notes, document platform-specific paste dispatch, and update README/README-ja to reflect Windows support.

## Changes
- usage.md: Windows notes (Terminal recommendation, audio/Paste guard notes)
- architecture.md: paste dispatcher and per-OS backends
- README.md / README-ja.md: mention Windows support and link to usage notes

## Test plan
- Docs-only changes; render in GitHub to verify formatting.

Fixes #9