### PR TITLE
packaging: add Windows classifier (issue #10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Environment :: MacOS X",
+        "Environment :: Win32 (MS Windows)",
     "Topic :: Multimedia :: Sound/Audio :: Analysis",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
## Summary
Declare Windows support in package metadata.

## Changes
- pyproject.toml: add `Environment :: Win32 (MS Windows)` classifier

## Test plan
- Metadata-only change. Build succeeds locally.

Fixes #10