### PR TITLE
feat: Linux paste backend with guard (issue #21)

### DIFF
--- a/src/presstalk/paste_linux.py
+++ b/src/presstalk/paste_linux.py
@@ -1,0 +1,180 @@
+import os
+import subprocess
+from typing import Callable, Optional, Tuple, Dict, Sequence, Union
+
+
+def _get_frontmost_app(*, runner: Optional[Callable[[list], Tuple[int, str]]] = None) -> Dict[str, str]:
+    """Best-effort frontmost app for Linux.
+
+    - X11: use xdotool/xprop to get WM_CLASS or window name
+    - Wayland (sway/wlroots): use swaymsg to get focused node app_id/name
+    Returns {'name': ...} or empty dict.
+    """
+    def _run_out(cmd: list) -> Tuple[int, str]:
+        try:
+            out = subprocess.check_output(cmd, text=True)
+            return (0, out.strip())
+        except Exception:
+            return (1, "")
+
+    r = runner or _run_out
+
+    # Try swaymsg (Wayland)
+    code, out = r(["swaymsg", "-t", "get_tree"])
+    if code == 0 and out:
+        try:
+            import json
+            tree = json.loads(out)
+            # Depth-first search for focused node
+            stack = [tree]
+            while stack:
+                node = stack.pop()
+                if node.get("focused"):
+                    name = node.get("app_id") or node.get("name") or ""
+                    if name:
+                        return {"name": str(name)}
+                for k in ("nodes", "floating_nodes", "windows", "childNodes"):
+                    if isinstance(node.get(k), list):
+                        stack.extend(node[k])
+        except Exception:
+            pass
+
+    # X11 via xdotool/xprop
+    code, wid = r(["xdotool", "getactivewindow"])
+    if code == 0 and wid:
+        code, klass = r(["xprop", "-id", wid, "WM_CLASS"])
+        if code == 0 and klass:
+            # format: WM_CLASS(STRING) = "xxx", "YYY"
+            try:
+                parts = [p.strip().strip('"') for p in klass.split("=", 1)[1].split(",")]
+                for p in parts:
+                    if p:
+                        return {"name": p}
+            except Exception:
+                pass
+        code, name = r(["xprop", "-id", wid, "_NET_WM_NAME"])
+        if code == 0 and name:
+            try:
+                val = name.split("=", 1)[1].strip().strip('"')
+                if val:
+                    return {"name": val}
+            except Exception:
+                pass
+
+    return {}
+
+
+essential_terminals = (
+    "gnome-terminal",
+    "org.gnome.Terminal",
+    "konsole",
+    "xterm",
+    "alacritty",
+    "kitty",
+    "wezterm",
+    "terminator",
+    "tilix",
+    "xfce4-terminal",
+    "lxterminal",
+    "io.elementary.terminal",
+)
+
+
+def _set_clipboard(text: str) -> bool:
+    # Try wl-copy (Wayland)
+    try:
+        p = subprocess.Popen(["wl-copy"], stdin=subprocess.PIPE, text=True)
+        p.communicate(text, timeout=1)
+        return True
+    except Exception:
+        pass
+    # Try xclip (X11)
+    try:
+        p = subprocess.Popen(["xclip", "-selection", "clipboard"], stdin=subprocess.PIPE, text=True)
+        p.communicate(text, timeout=1)
+        return True
+    except Exception:
+        pass
+    # Try xsel (fallback)
+    try:
+        p = subprocess.Popen(["xsel", "--clipboard", "--input"], stdin=subprocess.PIPE, text=True)
+        p.communicate(text, timeout=1)
+        return True
+    except Exception:
+        pass
+    return False
+
+
+def insert_text(
+    text: str,
+    *,
+    run_cmd: Optional[Callable[[list], int]] = None,
+    frontmost_getter: Optional[Callable[[], Dict[str, str]]] = None,
+    guard_enabled: Optional[bool] = None,
+    blocklist: Optional[Union[str, Sequence[str]]] = None,
+    clipboard_fn: Optional[Callable[[str], bool]] = None,
+) -> bool:
+    """Insert text at current cursor by clipboard swap + paste keystroke (Linux)."""
+    if text is None:
+        return True
+
+    # Guard
+    guard = guard_enabled if guard_enabled is not None else (
+        os.getenv("PT_PASTE_GUARD", "1") not in ("0", "false", "False")
+    )
+    if guard:
+        try:
+            fg = frontmost_getter() if frontmost_getter else _get_frontmost_app()
+        except Exception:
+            fg = {}
+        if fg:
+            name = (fg.get("name") or "").lower()
+            if blocklist is None:
+                block_env = os.getenv(
+                    "PT_PASTE_BLOCKLIST",
+                    ",".join(essential_terminals),
+                )
+                blocks = [s.strip().lower() for s in block_env.split(",") if s.strip()]
+            else:
+                if isinstance(blocklist, str):
+                    blocks = [s.strip().lower() for s in blocklist.split(",") if s.strip()]
+                else:
+                    blocks = [str(s).strip().lower() for s in blocklist if str(s).strip()]
+            if any(b and (name.find(b) != -1) for b in blocks):
+                return False
+
+    # Clipboard
+    if clipboard_fn is not None:
+        try:
+            if not clipboard_fn(text):
+                return False
+        except Exception:
+            return False
+    else:
+        if not _set_clipboard(text):
+            return False
+
+    # Paste keystroke
+    if run_cmd is not None:
+        try:
+            return run_cmd(["ctrl+v"]) == 0
+        except Exception:
+            return False
+
+    # Try pynput
+    try:
+        from pynput import keyboard  # type: ignore
+        kb = keyboard.Controller()
+        with kb.pressed(keyboard.Key.ctrl):
+            kb.press('v')
+            kb.release('v')
+        return True
+    except Exception:
+        pass
+
+    # X11 fallback via xdotool
+    try:
+        subprocess.run(["xdotool", "key", "--clearmodifiers", "ctrl+v"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except Exception:
+        return False

--- a/tests/test_paste_linux.py
+++ b/tests/test_paste_linux.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from presstalk.paste_linux import insert_text  # type: ignore
+
+
+class TestPasteLinux(unittest.TestCase):
+    def test_insert_text_with_stub_runner_and_clipboard(self):
+        calls = {"run": 0, "clip": 0}
+
+        def runner(cmd):
+            calls["run"] += 1
+            return 0
+
+        def clipboard_fn(text: str) -> bool:
+            calls["clip"] += 1
+            return True
+
+        ok = insert_text("hello", run_cmd=runner, clipboard_fn=clipboard_fn, frontmost_getter=lambda: {"name": "gedit"})
+        self.assertTrue(ok)
+        self.assertEqual(calls["clip"], 1)
+        self.assertEqual(calls["run"], 1)
+
+    def test_insert_none_returns_true(self):
+        self.assertTrue(insert_text(None, run_cmd=lambda _: 0, clipboard_fn=lambda t: True))
+
+    def test_paste_guard_blocks_terminal(self):
+        calls = {"run": 0, "clip": 0}
+
+        def runner(_cmd):
+            calls["run"] += 1
+            return 0
+
+        def clipboard_fn(text: str) -> bool:
+            calls["clip"] += 1
+            return True
+
+        def fg():
+            return {"name": "gnome-terminal"}
+
+        ok = insert_text("hello", run_cmd=runner, frontmost_getter=fg, clipboard_fn=clipboard_fn)
+        self.assertFalse(ok)
+        self.assertEqual(calls["run"], 0)
+        self.assertEqual(calls["clip"], 0)
+
+    def test_errors_fail_safely(self):
+        def bad_clip(_):
+            raise RuntimeError("boom")
+
+        def bad_run(_):
+            raise RuntimeError("boom")
+
+        ok = insert_text("hello", run_cmd=bad_run, clipboard_fn=bad_clip, frontmost_getter=lambda: {})
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add Linux paste backend with clipboard and keystroke handling, plus paste guard support.

## Changes
- `src/presstalk/paste_linux.py`: wl-copy/xclip/xsel clipboard, pynput/xdotool keystroke; frontmost app via swaymsg or xdotool+xprop
- Tests: `tests/test_paste_linux.py` with DI stubs (TDD)

## Test plan
- `uv run python -m unittest tests/test_paste_linux.py -v`

Fixes #21