### PR TITLE
feat: Linux paste dispatch + config defaults (issue #22)

### DIFF
--- a/src/presstalk/config.py
+++ b/src/presstalk/config.py
@@ -45,6 +45,11 @@ class Config:
         # OS-specific default paste guard blocklist
         if os.name == 'nt' or sys.platform == 'win32':  # type: ignore[name-defined]
             pblock = "cmd.exe,powershell.exe,pwsh.exe,WindowsTerminal.exe,wt.exe,conhost.exe"
+        elif sys.platform.startswith('linux'):
+            pblock = (
+                "gnome-terminal,org.gnome.Terminal,konsole,xterm,alacritty,kitty,"
+                "wezterm,terminator,tilix,xfce4-terminal,lxterminal,io.elementary.terminal"
+            )
         else:
             pblock = "Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2"
         slog = True

--- a/src/presstalk/paste.py
+++ b/src/presstalk/paste.py
@@ -4,6 +4,8 @@ if sys.platform == "darwin":
     from .paste_macos import insert_text  # noqa: F401
 elif sys.platform == "win32":
     from .paste_windows import insert_text  # noqa: F401
+elif sys.platform.startswith("linux"):
+    from .paste_linux import insert_text  # noqa: F401
 else:
     # Fallback: import macOS variant; callers can supply stubs in tests
     from .paste_macos import insert_text  # type: ignore # noqa: F401

--- a/tests/test_paste_dispatch.py
+++ b/tests/test_paste_dispatch.py
@@ -36,9 +36,14 @@ class TestPasteDispatch(unittest.TestCase):
         paste = _reload_paste('win32')
         self.assertIs(paste.insert_text, win_mod.insert_text)
 
+    def test_dispatch_linux_uses_linux_impl(self):
+        lin_mod = importlib.import_module('presstalk.paste_linux')
+        paste = _reload_paste('linux')
+        self.assertIs(paste.insert_text, lin_mod.insert_text)
+
     def test_dispatch_other_platforms_fallback_to_macos(self):
         mac_mod = importlib.import_module('presstalk.paste_macos')
-        paste = _reload_paste('linux')
+        paste = _reload_paste('freebsd')
         self.assertIs(paste.insert_text, mac_mod.insert_text)
 
 

--- a/tests/test_paste_guard_defaults.py
+++ b/tests/test_paste_guard_defaults.py
@@ -44,6 +44,24 @@ class TestPasteGuardDefaults(unittest.TestCase):
         finally:
             sys.platform = real
 
+    def test_linux_default_blocklist(self):
+        real = sys.platform
+        try:
+            sys.platform = 'linux'
+            cfg = Config()
+            bl = cfg.paste_blocklist
+            if isinstance(bl, str):
+                bl = [s.strip().lower() for s in bl.split(',') if s.strip()]
+            joined = ','.join(bl)
+            # expect a common terminal to be present
+            self.assertTrue(
+                any(k in joined for k in [
+                    'gnome-terminal','konsole','xterm','alacritty','kitty','wezterm','terminator','tilix'
+                ])
+            )
+        finally:
+            sys.platform = real
+
     def test_env_overrides_defaults_always(self):
         real = sys.platform
         try:


### PR DESCRIPTION
## Summary
Add Linux branch to paste dispatcher and OS-specific default paste guard blocklist in Config; update tests.

## Changes
- `presstalk.paste`: select `paste_linux` on Linux
- `Config`: Linux default blocklist added (`gnome-terminal,konsole,xterm,...`)
- Tests: dispatcher and defaults updated

## Test plan
- `uv run python -m unittest tests/test_paste_dispatch.py -v`
- `uv run python -m unittest tests/test_paste_guard_defaults.py -v`

Fixes #22