### PR TITLE
docs+packaging: Linux usage notes and classifier (issues #24, #25)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -5,7 +5,7 @@
 
 言語: [English](README.md) | [日本語](README-ja.md)
 
-音声入力ツール（プッシュトゥトーク, PTT）。コントロールキーを押している間だけ録音し、離すと最前面アプリのカーソル位置に文字起こし結果を貼り付けます。すべてローカルで動作します（サーバ不要）。macOS と Windows をサポートします。
+音声入力ツール（プッシュトゥトーク, PTT）。コントロールキーを押している間だけ録音し、離すと最前面アプリのカーソル位置に文字起こし結果を貼り付けます。すべてローカルで動作します（サーバ不要）。macOS / Windows / Linux をサポートします。
 
 - アーキテクチャ: docs/architecture.md
 - 使い方（日本語）: docs/usage-ja.md
@@ -62,7 +62,7 @@ Tips:
   - `make run-anywhere`
 
 ## 依存関係
-- Python 3.9+（macOS 13+ または Windows 10/11）
+- Python 3.9+（macOS 13+ / Windows 10/11 / Linux）
 - 開発ツール（macOS）: `xcode-select --install`
 - オーディオ（macOSで `sounddevice` が失敗する場合）: `brew install portaudio` → 再インストール
 - 権限: macOS はマイク+アクセシビリティ、Windows は前面アプリのテキスト入力フォーカスが必要
@@ -91,4 +91,4 @@ paste_blocklist:
 
 ライセンス: MIT（pyproject を参照）
 
-Windows の注意事項やペーストガードの既定値は `docs/usage.md` / `docs/usage-ja.md` を参照してください。
+Windows/Linux の注意事項やペーストガードの既定値は `docs/usage.md` / `docs/usage-ja.md` を参照してください。

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Language: [English](README.md) | [日本語](README-ja.md)
 
-Local voice input tool using push‑to‑talk (PTT). Hold a control key to record; release to insert transcribed text at the cursor in the frontmost app. Runs entirely on your machine (no server). macOS and Windows are supported.
+Local voice input tool using push‑to‑talk (PTT). Hold a control key to record; release to insert transcribed text at the cursor in the frontmost app. Runs entirely on your machine (no server). macOS, Windows, and Linux are supported.
 
 - Architecture: docs/architecture.md
 - Roadmap: docs/ROADMAP.md
@@ -107,7 +107,7 @@ All runtime dependencies are included by default (pynput, faster-whisper, numpy,
 
 ## Dependencies
 
-- Python 3.9+ on macOS 13+ or Windows 10/11.
+- Python 3.9+ on macOS 13+, Windows 10/11, or Linux.
 - Build tools (macOS): `xcode-select --install`.
 - Audio backend (macOS, if `sounddevice` build fails): `brew install portaudio`.
 - Permissions: macOS requires Microphone + Accessibility; Windows requires a focused text input to paste.
@@ -124,4 +124,4 @@ uv run presstalk run \
   --language ja --model small --prebuffer-ms 200 --min-capture-ms 1800
 ```
 
-See docs/usage.md for full instructions (including Windows notes) and permissions.
+See docs/usage.md for full instructions (including Windows/Linux notes) and permissions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,9 @@
 - Controller (`src/presstalk/controller.py`): Press/Release state machine, prebuffer push, live push, and finalize.
 - Orchestrator (`src/presstalk/orchestrator.py`): Coordinates capture lifecycle and pasting.
 - Paste (`src/presstalk/paste.py`): platform-dispatching `insert_text`.
-  - macOS: `paste_macos.py` (clipboard via pbcopy + Cmd+V via osascript)
-  - Windows: `paste_windows.py` (clipboard via clip.exe + Ctrl+V via pynput)
+  - macOS: `paste_macos.py` (pbcopy + osascript Cmd+V)
+  - Windows: `paste_windows.py` (clip.exe + pynput Ctrl+V)
+  - Linux: `paste_linux.py` (wl-copy/xclip/xsel + pynput or xdotool)
 
 ## Key Interfaces
 ```python

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -81,7 +81,20 @@ uv run presstalk run
 - 貼り付かない: アクセシビリティ許可、最前面アプリのテキスト入力フォーカスを確認。
 - 短すぎて結果が出ない: `--min-capture-ms 2000`、`--prebuffer-ms 200..300` を試す。
 
-## 9) 環境変数での既定値（任意）
+## 9) Linux の注意事項
+- 推奨パッケージ（Debian/Ubuntu 例）:
+```bash
+sudo apt-get update && sudo apt-get install -y \
+  portaudio19-dev libasound2-dev xclip xdotool
+```
+- Wayland: クリップボードに `wl-clipboard`（`wl-copy`）を導入。コンポジタ設定によりキー注入が制限される場合は `--console` を利用してください。
+```bash
+sudo apt-get install -y wl-clipboard
+```
+- セットアップ自体は macOS/Windows と同様に venv 作成→ `uv pip install -e .` → `simulate`/`run --console`。
+- ペーストガードの既定には一般的な Linux ターミナルが含まれます。YAML の `paste_blocklist:` か `PT_PASTE_BLOCKLIST` で上書き可能。
+
+## 10) 環境変数での既定値（任意）
 CLI引数の代わりに以下も利用可能（`src/presstalk/config.py`参照）:
 - `PT_LANGUAGE`（既定: `ja`）
 - `PT_SAMPLE_RATE`（既定: `16000`）
@@ -115,3 +128,4 @@ uv run presstalk run --mode hold --hotkey ctrl --language ja --model small --pre
   - 既定ブロックリスト（OS別）:
     - macOS: `Terminal,iTerm2,com.apple.Terminal,com.googlecode.iterm2`
     - Windows: `cmd.exe,powershell.exe,pwsh.exe,WindowsTerminal.exe,wt.exe,conhost.exe`
+    - Linux: `gnome-terminal,org.gnome.Terminal,konsole,xterm,alacritty,kitty,wezterm,terminator,tilix,xfce4-terminal,lxterminal,io.elementary.terminal`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# PressTalk Usage (macOS/Windows, Local-Only)
+# PressTalk Usage (macOS/Windows/Linux, Local-Only)
 
 ## Prerequisites
 - macOS 13+ (Apple Silicon or Intel)
@@ -79,12 +79,25 @@ Type `p` + Enter to press, `r` + Enter to release, `q` to quit.
 - No paste: check Accessibility permission and text focus in the frontmost app
 - Too short utterances: raise `min_capture_ms` or use small prebuffer
 
-## 9) Windows Notes
+## 9) Linux Notes
+- Recommended packages (Debian/Ubuntu):
+```bash
+sudo apt-get update && sudo apt-get install -y \
+  portaudio19-dev libasound2-dev xclip xdotool
+```
+- Wayland: install `wl-clipboard` for clipboard support; keystroke injection may be restricted by the compositor. Prefer `--console` mode if global key events are blocked.
+```bash
+sudo apt-get install -y wl-clipboard
+```
+- Setup is otherwise the same: create venv, `uv pip install -e .`, then `simulate`/`run --console`.
+- Paste guard defaults include common Linux terminals; override with YAML `paste_blocklist:` or `PT_PASTE_BLOCKLIST`.
+
+## 10) Windows Notes
 - Use Windows Terminal for proper ANSI color rendering.
 - Ensure audio devices are working; `sounddevice` uses PortAudio on Windows.
 - Clipboard and paste guard require a focused text input in the foreground app.
 
-## 10) Environment Variables (optional)
+## 11) Environment Variables (optional)
 - `PT_LANGUAGE`, `PT_SAMPLE_RATE`, `PT_CHANNELS`, `PT_PREBUFFER_MS`, `PT_MIN_CAPTURE_MS`, `PT_MODEL`
 - `PT_PASTE_GUARD`, `PT_PASTE_BLOCKLIST`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Environment :: MacOS X",
         "Environment :: Win32 (MS Windows)",
+        "Environment :: POSIX :: Linux",
     "Topic :: Multimedia :: Sound/Audio :: Analysis",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
## Summary
Add Linux setup/usage notes and paste dispatcher docs; add Linux classifier to package metadata.

## Changes
- Docs: usage (EN/JA) Linux sections; architecture paste dispatcher includes Linux; README updates
- Packaging: `Environment :: POSIX :: Linux` classifier in pyproject.toml

## Test plan
- Docs-only; metadata-only build ok locally (`uv run python -m unittest -v`)

Refs: #24 #25