### PR TITLE
Add cross-platform task runner; simplify README Quick Start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,30 +29,28 @@ venv:
 	$(UV) venv
 
 install:
-	$(UV) pip install -e .
+	$(UV) run python task.py install
 
 run:
-	$(UV) run presstalk run
+	$(UV) run python task.py run
 
 console:
-	$(UV) run presstalk run --console
+	$(UV) run python task.py run --console
 
 CHUNKS ?= hello world
 DELAY ?= 40
 simulate:
-	$(UV) run presstalk simulate --chunks $(CHUNKS) --delay-ms $(DELAY)
+	$(UV) run python task.py simulate --chunks $(CHUNKS) --delay-ms $(DELAY)
 
 test:
-	$(UV) run python -m unittest -v
+	$(UV) run python task.py test
 
 FILE ?= tests/test_controller.py
 test-file:
-	$(UV) run python -m unittest $(FILE) -v
+	$(UV) run python task.py test --file $(FILE)
 
 clean:
-	rm -rf build dist .pytest_cache
-	find . -name __pycache__ -prune -exec rm -rf {} +
-	find . -name '*.egg-info' -prune -exec rm -rf {} +
+	$(UV) run python task.py clean
 
 KEY ?= ctrl
 MODE ?= hold
@@ -114,22 +112,10 @@ run-anywhere:
 	fi
 
 lint:
-	@if command -v ruff >/dev/null 2>&1; then \
-		$(UV) run ruff check . ; \
-	elif command -v flake8 >/dev/null 2>&1; then \
-		$(UV) run flake8 . ; \
-	else \
-		echo "No linter found (install ruff or flake8)" ; \
-	fi
+	$(UV) run python task.py lint
 
 format:
-	@if command -v ruff >/dev/null 2>&1; then \
-		$(UV) run ruff format . ; \
-	elif command -v black >/dev/null 2>&1; then \
-		$(UV) run black . ; \
-	else \
-		echo "No formatter found (install ruff or black)" ; \
-	fi
+	$(UV) run python task.py format
 
 typecheck:
 	@if command -v mypy >/dev/null 2>&1; then \

--- a/README-ja.md
+++ b/README-ja.md
@@ -15,29 +15,24 @@
 
 ## クイックスタート
 
-まずクローン:
+方法A（一発・グローバル推奨）
 ```bash
-git clone https://github.com/lostandfound/presstalk.git
-cd presstalk
-```
-
-方法A（推奨・No‑CD 一発セットアップ）:
-```bash
-make bootstrap
+uv run python task.py bootstrap
 # 以後どこからでも
 presstalk
 ```
 
-方法B（プロジェクト内 venv）:
+方法B（ローカル開発・プロジェクト venv）
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install -e .
+# 実行（グローバルホットキー）/ コンソールモード
 uv run presstalk
+uv run presstalk --console
 ```
 Tips:
 - 初回は macOS のマイク/アクセシビリティ許可が必要です。
-- 既定ホットキーは `ctrl`。押して録音、離すとローカルで文字起こししてカーソル位置に貼り付けます。
-- 既定でペーストガード有効（Terminal/iTerm には貼り付けを抑止、設定で変更可能）。
+- 既定ホットキーは `ctrl`。押して録音、離すとローカルで貼り付け。
 
 ## できること（概要）
 - どのテキスト入力欄でも、キー押下中のみ録音→キーを離すと貼り付け。
@@ -45,21 +40,19 @@ Tips:
 - faster‑whisper によるオフライン ASR。音声は端末外へ送信しません。
 - ペーストガードで Terminal/iTerm を回避（YAML で調整可能）。
 
-## Makefile ショートカット
-- `make venv && source .venv/bin/activate && make install`
-- `make run` / `make console`
-- `make simulate CHUNKS="hello world" DELAY=40`
-- `make test` / `make test-file FILE=tests/test_controller.py`
-- `make lint` / `make format` / `make typecheck`
+## タスク実行（クロスプラットフォーム）
+共通のワークフローは task.py を使います:
+- インストール: `uv run python task.py install`
+- テスト: `uv run python task.py test`
+- シミュレーション: `uv run python task.py simulate --chunks hello world --delay-ms 40`
+- 実行: `uv run python task.py run`（または `--console`）
 
-## リポジトリに移動せずに起動する（No‑CD Setup）
-- 一発セットアップ（uv/pipx/venv を自動判別）:
-  - `make bootstrap`
-  - 以後はどこからでも: `presstalk run`（または `pt` エイリアス）
-- グローバルインストール（uv）:
-  - `make install-global` 実行後、`~/.local/bin` を PATH に追加（`make path-zsh` か `make path-bash`）
-- いま即起動（インストール不要・リポジトリから実行）:
-  - `make run-anywhere`
+Unix 環境では Makefile のラッパーもありますが任意です。詳細は docs 参照。
+
+## ドキュメント
+- 使い方（英語）: docs/usage.md（Windows/macOS/Linux の注意・YAML・Makefile ラッパー）
+- 使い方（日本語）: docs/usage-ja.md
+- コマンド一覧: docs/commands.md
 
 ## 依存関係
 - Python 3.9+（macOS 13+ / Windows 10/11 / Linux）

--- a/README.md
+++ b/README.md
@@ -16,30 +16,24 @@ Local voice input tool using push‑to‑talk (PTT). Hold a control key to recor
 
 ## Quick Start
 
-Clone first:
+Option A — One-shot (global, recommended)
 ```bash
-git clone https://github.com/lostandfound/presstalk.git
-cd presstalk
-```
-
-Option A — No-CD (recommended, 1-step setup):
-```bash
-make bootstrap
+uv run python task.py bootstrap
 # then from anywhere
 presstalk
 ```
 
-Option B — Project-local venv:
+Option B — Local dev (project venv)
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install -e .
+# Run locally (global hotkey) or console mode
 uv run presstalk
+uv run presstalk --console
 ```
-Tips:
-- On first run, macOS prompts for Microphone and Accessibility permissions.
-- Hold the chosen key (default `ctrl`) to record. When you release it, PressTalk transcribes locally and pastes the text at your current cursor position in the active app.
-- Paste guard is enabled by default: paste is skipped when Terminal/iTerm is frontmost (configurable).
-  - Tip: `presstalk` with no args equals `presstalk run`.
+Notes:
+- macOS prompts for Microphone + Accessibility on first run.
+- Hold the key (default `ctrl`) to record; release to paste.
 
 ## What It Does
 - Voice input for any text field: record while holding a key, paste on release.
@@ -47,21 +41,14 @@ Tips:
 - Offline ASR with faster‑whisper; audio never leaves your device.
 - Paste guard avoids Terminal/iTerm by default; customize via YAML.
 
-## Makefile Shortcuts
-- `make venv && source .venv/bin/activate && make install`
-- `make run` / `make console`
-- `make simulate CHUNKS="hello world" DELAY=40`
-- `make test` / `make test-file FILE=tests/test_controller.py`
-- `make lint` / `make format` / `make typecheck`
+## Tasks (Cross-Platform)
+Use the task runner for common workflows:
+- Install: `uv run python task.py install`
+- Test: `uv run python task.py test`
+- Simulate: `uv run python task.py simulate --chunks hello world --delay-ms 40`
+- Run: `uv run python task.py run` (or `--console`)
 
-## No-CD Setup (Run from anywhere)
-- One-shot setup (auto-detects uv/pipx/venv):
-  - `make bootstrap`
-  - Then run globally: `presstalk run` (or `pt` if alias was added)
-- Quick global install (uv):
-  - `make install-global` and ensure `~/.local/bin` is in PATH (`make path-zsh` or `make path-bash`)
-- Run now without install (from repo):
-  - `make run-anywhere`
+For Unix users, a Makefile wrapper exists but is optional. See docs.
 
 ## Configuration (YAML)
 - Auto-discovery: `presstalk.yaml` in the repository root (editable installs).
@@ -91,19 +78,10 @@ uv run presstalk run --console
 ```
 - Type `p` then `r` to record/release, `q` to quit (no global hotkey).
 
-## Install
-
-Recommended with uv (or pip):
-
-```bash
-# Inside this repo (editable dev install)
-uv pip install -e .
-
-# Or, when published to PyPI (example)
-# uv pip install presstalk
-```
-
-All runtime dependencies are included by default (pynput, faster-whisper, numpy, sounddevice).
+## Docs
+- Usage: docs/usage.md (Windows/macOS/Linux notes, YAML config, Makefile wrapper)
+- 日本語: docs/usage-ja.md
+- Commands: docs/commands.md
 
 ## Dependencies
 
@@ -114,14 +92,4 @@ All runtime dependencies are included by default (pynput, faster-whisper, numpy,
 
 Note: Docker is not supported for runtime use (microphone, global hotkeys, and paste require host permissions).
 
-## Run (examples)
-
-```bash
-uv run presstalk simulate --chunks hello world --delay-ms 40
-
-uv run presstalk run \
-  --mode hold \
-  --language ja --model small --prebuffer-ms 200 --min-capture-ms 1800
-```
-
-See docs/usage.md for full instructions (including Windows/Linux notes) and permissions.
+For advanced setup (global install, run-anywhere), see docs.

--- a/docs/usage-ja.md
+++ b/docs/usage-ja.md
@@ -69,19 +69,30 @@ uv run presstalk run
   - hold: `p` + Enter で開始、`r` + Enter で停止、`q` で終了
   - 注意: 最終化（[PT] Finalizing...）中は終了（q）が無効化されます。
 
-## 7) 推奨設定値
+## 7) タスクランナー（Make不要・推奨）
+Windows/macOS/Linux 共通で `task.py` を利用できます:
+```bash
+uv run python task.py install
+uv run python task.py test
+uv run python task.py simulate --chunks hello world --delay-ms 40
+uv run python task.py run          # グローバルホットキー
+uv run python task.py run --console
+uv run python task.py clean
+```
+
+## 8) 推奨設定値
 - 言語: `--language ja`
 - モデル: `--model small`（既定）
 - プリバッファ: `--prebuffer-ms 0..300`（押下直後の欠け対策。0 で無効）
 - 最小録音時間: `--min-capture-ms 1800`（短押し対策）
 
-## 8) トラブルシュート
+## 9) トラブルシュート
 - `sounddevice` エラー: `brew install portaudio` → `uv pip install sounddevice` 再試行
 - モデル初回が遅い: 初回ダウンロード/キャッシュのため。2回目以降は高速化。
 - 貼り付かない: アクセシビリティ許可、最前面アプリのテキスト入力フォーカスを確認。
 - 短すぎて結果が出ない: `--min-capture-ms 2000`、`--prebuffer-ms 200..300` を試す。
 
-## 9) Linux の注意事項
+## 10) Linux の注意事項
 - 推奨パッケージ（Debian/Ubuntu 例）:
 ```bash
 sudo apt-get update && sudo apt-get install -y \
@@ -94,7 +105,7 @@ sudo apt-get install -y wl-clipboard
 - セットアップ自体は macOS/Windows と同様に venv 作成→ `uv pip install -e .` → `simulate`/`run --console`。
 - ペーストガードの既定には一般的な Linux ターミナルが含まれます。YAML の `paste_blocklist:` か `PT_PASTE_BLOCKLIST` で上書き可能。
 
-## 10) 環境変数での既定値（任意）
+## 11) 環境変数での既定値（任意）
 CLI引数の代わりに以下も利用可能（`src/presstalk/config.py`参照）:
 - `PT_LANGUAGE`（既定: `ja`）
 - `PT_SAMPLE_RATE`（既定: `16000`）
@@ -103,14 +114,14 @@ CLI引数の代わりに以下も利用可能（`src/presstalk/config.py`参照�
 - `PT_MIN_CAPTURE_MS`（既定: `1800`）
 - `PT_MODEL`（既定: `small`）
 
-## 10) 既知の制限と今後
+## 12) 既知の制限と今後
 - グローバルホットキーと貼り付けガードは実装済み（既定で有効）。
 - ダイアライゼーションや逐次確定は今後の拡張対象。
 
 ---
 困ったら `uv run presstalk simulate` の結果とエラーメッセージを共有してください。最小の再現手順からサポートします。
 
-## 11) グローバルホットキー（既定）
+## 13) グローバルホットキー（既定）
 - 既定でグローバルホットキーが有効です（`--console` を付けると対話モード）。
 - 実行例（Ctrlを押している間だけ録音）:
 ```bash
@@ -119,7 +130,7 @@ uv run presstalk run --mode hold --hotkey ctrl --language ja --model small --pre
 - ホットキー指定例: `ctrl` / `cmd` / `alt` / `space` / 文字キー（例: `a`）
 - 注意: macOS ではアクセシビリティ許可が必要です（Terminalを有効に）。
 
-## 12) 貼り付けガード（Terminal/iTerm を避ける）
+## 14) 貼り付けガード（Terminal/iTerm を避ける）
 - 既定で、最前面アプリが Terminal/iTerm の場合は自動貼り付けを抑止します。
 - 制御は環境変数で可能:
   - `PT_PASTE_GUARD=1`（既定1=有効、0で無効）

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,19 +67,30 @@ uv run presstalk run --console
 ```
 Type `p` + Enter to press, `r` + Enter to release, `q` to quit.
 
-## 7) Recommended Settings
+## 7) Cross-Platform Tasks (no Make)
+- Prefer these commands on Windows/macOS/Linux to avoid shell differences:
+```bash
+uv run python task.py install
+uv run python task.py test
+uv run python task.py simulate --chunks hello world --delay-ms 40
+uv run python task.py run          # global hotkey
+uv run python task.py run --console
+uv run python task.py clean
+```
+
+## 8) Recommended Settings
 - Language: `--language ja`
 - Model: `--model small`
 - Prebuffer: `--prebuffer-ms 0..300`
 - Minimum capture: `--min-capture-ms 1800`
 
-## 8) Troubleshooting
+## 9) Troubleshooting
 - `sounddevice` errors: `brew install portaudio` then reinstall
 - First run is slow: model download/cache; subsequent runs are faster
 - No paste: check Accessibility permission and text focus in the frontmost app
 - Too short utterances: raise `min_capture_ms` or use small prebuffer
 
-## 9) Linux Notes
+## 10) Linux Notes
 - Recommended packages (Debian/Ubuntu):
 ```bash
 sudo apt-get update && sudo apt-get install -y \
@@ -92,12 +103,12 @@ sudo apt-get install -y wl-clipboard
 - Setup is otherwise the same: create venv, `uv pip install -e .`, then `simulate`/`run --console`.
 - Paste guard defaults include common Linux terminals; override with YAML `paste_blocklist:` or `PT_PASTE_BLOCKLIST`.
 
-## 10) Windows Notes
+## 11) Windows Notes
 - Use Windows Terminal for proper ANSI color rendering.
 - Ensure audio devices are working; `sounddevice` uses PortAudio on Windows.
 - Clipboard and paste guard require a focused text input in the foreground app.
 
-## 11) Environment Variables (optional)
+## 12) Environment Variables (optional)
 - `PT_LANGUAGE`, `PT_SAMPLE_RATE`, `PT_CHANNELS`, `PT_PREBUFFER_MS`, `PT_MIN_CAPTURE_MS`, `PT_MODEL`
 - `PT_PASTE_GUARD`, `PT_PASTE_BLOCKLIST`
 

--- a/task.py
+++ b/task.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Cross-platform task runner for PressTalk.
+
+Usage:
+  uv run python task.py <task> [options]
+
+Tasks:
+  - clean:     Remove build/ dist/ .pytest_cache and all **/__pycache__
+  - install:   uv pip install -e .
+  - test:      uv run python -m unittest -v [--file PATH]
+  - simulate:  uv run presstalk simulate [--chunks ... --delay-ms INT]
+  - run:       uv run presstalk run [--console]
+  - lint:      Try ruff or flake8 (if available); otherwise no-op message
+  - format:    Try ruff format or black (if available); otherwise no-op message
+
+Common flags:
+  --dry-run / -n   Show actions without executing
+  --verbose / -v   Print commands and details
+
+This script avoids shell-specific syntax to work on Windows/macOS/Linux.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence, Optional
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+class TaskError(RuntimeError):
+    pass
+
+
+def run_cmd(cmd: Sequence[str], *, dry_run: bool = False, verbose: bool = False) -> int:
+    if verbose or dry_run:
+        print("$", " ".join(cmd))
+    if dry_run:
+        return 0
+    try:
+        return subprocess.call(list(cmd))
+    except FileNotFoundError as e:
+        raise TaskError(f"Command not found: {cmd[0]}") from e
+
+
+def which(prog: str) -> Optional[str]:
+    return shutil.which(prog)
+
+
+def task_clean(dry_run: bool, verbose: bool) -> None:
+    targets: List[Path] = []
+    # Fixed targets
+    for name in ("build", "dist", ".pytest_cache"):
+        p = ROOT / name
+        if p.exists():
+            targets.append(p)
+    # Recursively collect __pycache__
+    targets.extend(Path(ROOT).rglob("__pycache__"))
+
+    if not targets and verbose:
+        print("Nothing to clean.")
+
+    for p in targets:
+        if p.is_dir():
+            if verbose or dry_run:
+                print(f"rm -rf {p.relative_to(ROOT)}")
+            if not dry_run:
+                shutil.rmtree(p, ignore_errors=True)
+        else:
+            if verbose or dry_run:
+                print(f"rm -f {p.relative_to(ROOT)}")
+            if not dry_run:
+                try:
+                    p.unlink()
+                except FileNotFoundError:
+                    pass
+
+
+def task_install(dry_run: bool, verbose: bool) -> None:
+    code = run_cmd(["uv", "pip", "install", "-e", "."], dry_run=dry_run, verbose=verbose)
+    if code != 0:
+        raise TaskError(f"install failed with exit code {code}")
+
+
+def task_test(file: Optional[str], dry_run: bool, verbose: bool) -> None:
+    # Use discovery by default to match repo guidelines
+    if file:
+        args = ["uv", "run", "python", "-m", "unittest", file, "-v"]
+    else:
+        args = [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "unittest",
+            "discover",
+            "-v",
+            "-s",
+            "tests",
+            "-p",
+            "test_*.py",
+        ]
+    code = run_cmd(args, dry_run=dry_run, verbose=verbose)
+    if code != 0:
+        raise TaskError(f"tests failed with exit code {code}")
+
+
+def task_simulate(chunks: Optional[Iterable[str]], delay_ms: Optional[int], dry_run: bool, verbose: bool) -> None:
+    args: List[str] = ["uv", "run", "presstalk", "simulate"]
+    if chunks:
+        args.append("--chunks")
+        args.extend(list(chunks))
+    if delay_ms is not None:
+        args.extend(["--delay-ms", str(delay_ms)])
+    code = run_cmd(args, dry_run=dry_run, verbose=verbose)
+    if code != 0:
+        raise TaskError(f"simulate failed with exit code {code}")
+
+
+def task_run(console: bool, dry_run: bool, verbose: bool) -> None:
+    args: List[str] = ["uv", "run", "presstalk", "run"]
+    if console:
+        args.append("--console")
+    code = run_cmd(args, dry_run=dry_run, verbose=verbose)
+    if code != 0:
+        raise TaskError(f"run failed with exit code {code}")
+
+
+def task_lint(dry_run: bool, verbose: bool) -> None:
+    # Prefer ruff, fallback to flake8; otherwise no-op message
+    if which("ruff"):
+        code = run_cmd(["uv", "run", "ruff", "check", "."], dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("lint failed")
+        return
+    if which("flake8"):
+        code = run_cmd(["uv", "run", "flake8", "."], dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("lint failed")
+        return
+    print("No linter found (install ruff or flake8). Skipping.")
+
+
+def task_format(dry_run: bool, verbose: bool) -> None:
+    # Prefer ruff format, fallback to black; otherwise no-op message
+    if which("ruff"):
+        code = run_cmd(["uv", "run", "ruff", "format", "."], dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("format failed")
+        return
+    if which("black"):
+        code = run_cmd(["uv", "run", "black", "."], dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("format failed")
+        return
+    print("No formatter found (install ruff or black). Skipping.")
+
+
+def task_install_global(dry_run: bool, verbose: bool) -> None:
+    if not which("uv"):
+        raise TaskError("'uv' not found; install uv or use 'bootstrap' (will try pipx/venv)")
+    code = run_cmd(["uv", "tool", "install", "--editable", "."], dry_run=dry_run, verbose=verbose)
+    if code != 0:
+        raise TaskError("install-global failed")
+    print("Installed as a user tool. Ensure ~/.local/bin (or equivalent) is in PATH.")
+
+
+def task_bootstrap(dry_run: bool, verbose: bool) -> None:
+    # 1) Prefer uv tool install (global shim)
+    if which("uv"):
+        code = run_cmd(["uv", "tool", "install", "--editable", "."], dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("bootstrap: uv tool install failed")
+        print("[ok] presstalk installed globally via uv. If not found, add ~/.local/bin to PATH.")
+        return
+    # 2) Fallback to pipx if available
+    if which("pipx"):
+        code = run_cmd(["pipx", "install", "."], dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("bootstrap: pipx install failed")
+        print("[ok] presstalk installed globally via pipx. Run 'pipx ensurepath' if needed.")
+        return
+    # 3) Final fallback: create venv under ~/.venvs/presstalk and print usage
+    home = Path.home()
+    venv_dir = home / ".venvs" / "presstalk"
+    py = "python" if sys.platform == "win32" else "python3"
+    cmds = [
+        [py, "-m", "venv", str(venv_dir)],
+        [str(venv_dir / ("Scripts" if sys.platform == "win32" else "bin") / py), "-m", "pip", "install", "-U", "pip"],
+        [str(venv_dir / ("Scripts" if sys.platform == "win32" else "bin") / py), "-m", "pip", "install", "-e", "."],
+    ]
+    for c in cmds:
+        code = run_cmd(c, dry_run=dry_run, verbose=verbose)
+        if code != 0:
+            raise TaskError("bootstrap: venv setup failed")
+    exe = venv_dir / ("Scripts" if sys.platform == "win32" else "bin") / "presstalk"
+    print(f"[ok] venv ready at {venv_dir}")
+    if sys.platform == "win32":
+        print(f"Run: {exe} run")
+    else:
+        print(f"Add alias, e.g.: echo \"alias pt='{exe} run'\" >> ~/.zshrc && source ~/.zshrc")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="task.py", description="Cross-platform tasks for PressTalk")
+    p.add_argument("--dry-run", "-n", action="store_true", help="Show actions without executing")
+    p.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+
+    sp = p.add_subparsers(dest="task", required=True)
+
+    sp_clean = sp.add_parser("clean", help="Remove build artifacts and caches")
+
+    sp_install = sp.add_parser("install", help="Editable install via uv")
+
+    sp_test = sp.add_parser("test", help="Run unit tests")
+    sp_test.add_argument("--file", help="Run a specific test file (e.g., tests/test_controller.py)")
+
+    sp_sim = sp.add_parser("simulate", help="Run simulated capture")
+    sp_sim.add_argument("--chunks", nargs="+", help="Text chunks to simulate (space-separated)")
+    sp_sim.add_argument("--delay-ms", type=int, default=None, help="Inter-chunk delay in ms")
+
+    sp_run = sp.add_parser("run", help="Run PressTalk locally")
+    sp_run.add_argument("--console", action="store_true", help="Use console mode instead of global hotkey")
+
+    sp.add_parser("lint", help="Run linter if available (ruff/flake8)")
+    sp.add_parser("format", help="Run formatter if available (ruff/black)")
+
+    sp.add_parser("install-global", help="Install globally via uv tool (shim)")
+    sp.add_parser("bootstrap", help="One-shot setup: uv tool install or pipx, fallback to venv")
+
+    sp.add_parser("help", help="Show this help")
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    dry = bool(args.dry_run)
+    verbose = bool(args.verbose)
+
+    try:
+        if args.task == "clean":
+            task_clean(dry, verbose)
+        elif args.task == "install":
+            task_install(dry, verbose)
+        elif args.task == "test":
+            task_test(getattr(args, "file", None), dry, verbose)
+        elif args.task == "simulate":
+            task_simulate(getattr(args, "chunks", None), getattr(args, "delay_ms", None), dry, verbose)
+        elif args.task == "run":
+            task_run(getattr(args, "console", False), dry, verbose)
+        elif args.task == "lint":
+            task_lint(dry, verbose)
+        elif args.task == "format":
+            task_format(dry, verbose)
+        elif args.task == "install-global":
+            task_install_global(dry, verbose)
+        elif args.task == "bootstrap":
+            task_bootstrap(dry, verbose)
+        elif args.task == "help":
+            parser.print_help()
+        else:
+            parser.error(f"Unknown task: {args.task}")
+        return 0
+    except TaskError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,156 @@
+import io
+import os
+import shutil
+import sys
+from pathlib import Path
+from unittest import TestCase, mock
+
+import task
+
+
+class TestTaskRunner(TestCase):
+    def test_help_task_prints_usage(self):
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            rc = task.main(["help"])
+        self.assertEqual(rc, 0)
+        self.assertIn("Cross-platform tasks for PressTalk", buf.getvalue())
+
+    def test_install_dry_run(self):
+        with mock.patch.object(task, "subprocess") as m_sub:
+            rc = task.main(["--dry-run", "-v", "install"])
+            self.assertEqual(rc, 0)
+            m_sub.call.assert_not_called()
+
+    def test_test_all_and_file_dry_run(self):
+        with mock.patch.object(task, "subprocess") as m_sub:
+            rc = task.main(["--dry-run", "-v", "test"])
+            self.assertEqual(rc, 0)
+            m_sub.call.assert_not_called()
+
+        with mock.patch.object(task, "subprocess") as m_sub:
+            rc = task.main(["--dry-run", "-v", "test", "--file", "tests/test_controller.py"])
+            self.assertEqual(rc, 0)
+            m_sub.call.assert_not_called()
+
+    def test_simulate_and_run_dry_run(self):
+        with mock.patch.object(task, "subprocess") as m_sub:
+            rc = task.main(["--dry-run", "-v", "simulate", "--chunks", "hello", "world", "--delay-ms", "40"])
+            self.assertEqual(rc, 0)
+            m_sub.call.assert_not_called()
+
+    def test_install_global_with_uv(self):
+        with mock.patch.object(task, "which", return_value="/usr/bin/uv"):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["install-global"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["uv", "tool", "install", "--editable", "."])
+
+    def test_bootstrap_prefers_uv(self):
+        with mock.patch.object(task, "which", side_effect=["/usr/bin/uv"]):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["bootstrap"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["uv", "tool", "install", "--editable", "."])
+
+    def test_bootstrap_uses_pipx_when_no_uv(self):
+        with mock.patch.object(task, "which", side_effect=[None, "/usr/bin/pipx"]):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["bootstrap"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["pipx", "install", "."])
+
+    def test_bootstrap_fallback_venv(self):
+        with mock.patch.object(task, "which", side_effect=[None, None]):
+            with mock.patch.object(task, "subprocess") as m_sub, \
+                 mock.patch.object(task, "Path") as m_path, \
+                 mock.patch.object(task, "sys") as m_sys:
+                m_sub.call.return_value = 0
+                # Simulate POSIX
+                m_sys.platform = "darwin"
+                # Fake home
+                fake_home = Path.cwd() / ".tmp_home"
+                fake_home.mkdir(exist_ok=True)
+                m_path.home.return_value = fake_home
+                rc = task.main(["bootstrap"])
+                self.assertEqual(rc, 0)
+                # First command should be python3 -m venv <dir>
+                first_call = m_sub.call.call_args_list[0][0][0]
+                self.assertEqual(first_call[:3], ["python3", "-m", "venv"]) 
+
+        with mock.patch.object(task, "subprocess") as m_sub:
+            rc = task.main(["--dry-run", "-v", "run", "--console"])
+            self.assertEqual(rc, 0)
+            m_sub.call.assert_not_called()
+
+    def test_lint_with_ruff(self):
+        with mock.patch.object(task, "which", return_value="/usr/bin/ruff"):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["-v", "lint"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["uv", "run", "ruff", "check", "."])
+
+    def test_lint_with_flake8(self):
+        with mock.patch.object(task, "which", side_effect=[None, "/usr/bin/flake8"]):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["-v", "lint"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["uv", "run", "flake8", "."])
+
+    def test_lint_none_available(self):
+        with mock.patch.object(task, "which", return_value=None):
+            buf = io.StringIO()
+            rc = None
+            with mock.patch("sys.stdout", buf):
+                rc = task.main(["lint"])  # prints message, succeeds
+            self.assertEqual(rc, 0)
+            self.assertIn("No linter found", buf.getvalue())
+
+    def test_format_with_ruff(self):
+        with mock.patch.object(task, "which", return_value="/usr/bin/ruff"):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["-v", "format"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["uv", "run", "ruff", "format", "."])
+
+    def test_format_with_black(self):
+        with mock.patch.object(task, "which", side_effect=[None, "/usr/bin/black"]):
+            with mock.patch.object(task, "subprocess") as m_sub:
+                m_sub.call.return_value = 0
+                rc = task.main(["-v", "format"])
+                self.assertEqual(rc, 0)
+                m_sub.call.assert_called_with(["uv", "run", "black", "."])
+
+    def test_format_none_available(self):
+        with mock.patch.object(task, "which", return_value=None):
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                rc = task.main(["format"])  # prints message, succeeds
+            self.assertEqual(rc, 0)
+            self.assertIn("No formatter found", buf.getvalue())
+
+    def test_clean_dry_run_outputs(self):
+        # Create controlled targets in repo root
+        build = Path("build"); dist = Path("dist"); cache = Path(".pytest_cache")
+        for p in (build, dist, cache):
+            p.mkdir(parents=True, exist_ok=True)
+        try:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                rc = task.main(["--dry-run", "-v", "clean"])
+            self.assertEqual(rc, 0)
+            out = buf.getvalue()
+            self.assertIn("rm -rf build", out)
+            self.assertIn("rm -rf dist", out)
+            self.assertIn("rm -rf .pytest_cache", out)
+        finally:
+            # Clean up created dirs (if they still exist)
+            for p in (build, dist, cache):
+                if p.exists():
+                    shutil.rmtree(p, ignore_errors=True)


### PR DESCRIPTION
Purpose
- Replace Unix-centric Makefile workflows with a cross-platform Python task runner (task.py) for consistent DX across Windows/macOS/Linux.

Summary of changes
- Add task.py: clean/install/test/simulate/run/lint/format + help/install-global/bootstrap; --dry-run/--verbose common flags.
- Makefile: delegate common targets to task.py.
- Docs: simplify README Quick Start to presstalk; move details to docs; usage docs updated (EN/JA).
- Tests: add tests/test_task.py (15 tests) covering help/lint/format/clean/install-global/bootstrap and dry-run flows.

Testing notes
- Local: uv run python task.py test → 68 tests OK (includes new task tests).
- Manual sanity: uv run python task.py help; install --dry-run; clean; run/ simulate dry-runs.

Impact
- No CI configured; local commands unchanged for presstalk CLI.
- Windows users get first-class parity via task.py. Makefile remains a thin, optional wrapper.

Closes: N/A (DX improvement)
