### PR TITLE
Refactor: unify env boolean parsing (constants.is_env_enabled)

### DIFF
--- a/src/presstalk/config.py
+++ b/src/presstalk/config.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 import sys
 from typing import Optional, Any, Dict
+from .constants import is_env_enabled
 
 try:
     import yaml  # type: ignore
@@ -101,11 +102,11 @@ class Config:
             out['model'] = v
         # paste guard envs
         if (v := os.getenv("PT_PASTE_GUARD")) is not None:
-            out['paste_guard'] = v not in ("0", "false", "False")
+            out['paste_guard'] = is_env_enabled(v)
         if (v := os.getenv("PT_PASTE_BLOCKLIST")) is not None:
             out['paste_blocklist'] = v
         if (v := os.getenv("PT_NO_LOGO")) is not None:
-            out['show_logo'] = False if v not in ("0", "false", "False") else True
+            out['show_logo'] = not is_env_enabled(v)
         if (v := os.getenv("PT_LOGO_STYLE")) is not None:
             out['logo_style'] = v
         return out

--- a/src/presstalk/constants.py
+++ b/src/presstalk/constants.py
@@ -1,0 +1,18 @@
+from typing import Optional, Iterable, Tuple
+
+# Canonical falsy string representations used for env toggles
+FALSY_VALUES: Tuple[str, ...] = ("0", "false")
+
+
+def is_env_enabled(env_var: Optional[str], default: bool = True) -> bool:
+    """Return True if the env_var indicates an enabled flag.
+
+    - None returns the provided default
+    - Comparison is case-insensitive; leading/trailing spaces ignored
+    - Values considered falsy: "0", "false"
+    """
+    if env_var is None:
+        return default
+    val = env_var.strip().lower()
+    return val not in FALSY_VALUES
+

--- a/src/presstalk/paste_common.py
+++ b/src/presstalk/paste_common.py
@@ -1,5 +1,6 @@
 import os
 from typing import Dict, Optional, Sequence, Union, List
+from .constants import is_env_enabled
 
 
 class PasteGuard:
@@ -18,9 +19,7 @@ class PasteGuard:
         if guard_enabled is not None:
             return bool(guard_enabled)
         env = os.getenv("PT_PASTE_GUARD")
-        if env is not None:
-            return env.lower() not in ("0", "false")
-        return True
+        return is_env_enabled(env, default=True)
 
     @staticmethod
     def _effective_blocklist(
@@ -63,4 +62,3 @@ class PasteGuard:
                 if b in t:
                     return True
         return False
-

--- a/tests/test_config_refactor.py
+++ b/tests/test_config_refactor.py
@@ -23,6 +23,21 @@ class TestConfigRefactorHelpers(unittest.TestCase):
         ]:
             os.environ.pop(k, None)
 
+    def tearDown(self):
+        for k in [
+            "PT_LANGUAGE",
+            "PT_SAMPLE_RATE",
+            "PT_CHANNELS",
+            "PT_PREBUFFER_MS",
+            "PT_MIN_CAPTURE_MS",
+            "PT_MODEL",
+            "PT_PASTE_GUARD",
+            "PT_PASTE_BLOCKLIST",
+            "PT_NO_LOGO",
+            "PT_LOGO_STYLE",
+        ]:
+            os.environ.pop(k, None)
+
     def test_get_defaults_os_blocklist(self):
         c = Config()  # will run __post_init__, but we only call helper below
         real = sys.platform
@@ -107,4 +122,3 @@ class TestConfigRefactorHelpers(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,29 @@
+import unittest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from presstalk.constants import is_env_enabled, FALSY_VALUES  # type: ignore
+
+
+class TestConstants(unittest.TestCase):
+    def test_falsy_values_set(self):
+        # Ensure expected canonical strings are represented
+        self.assertIn("0", FALSY_VALUES)
+        # case-insensitive handling is implemented in is_env_enabled
+        self.assertIn("false", [s.lower() for s in FALSY_VALUES])
+
+    def test_is_env_enabled_none_uses_default(self):
+        self.assertTrue(is_env_enabled(None, default=True))
+        self.assertFalse(is_env_enabled(None, default=False))
+
+    def test_is_env_enabled_recognizes_common_values(self):
+        for v in ["0", "false", "False", " FALSE "]:
+            self.assertFalse(is_env_enabled(v))
+        for v in ["1", "true", "True", "yes", "on", "random", ""]:
+            self.assertTrue(is_env_enabled(v))
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Background
- Magic strings for env boolean parsing were duplicated across modules.

Changes
- Add src/presstalk/constants.py with FALSY_VALUES and is_env_enabled().
- Use is_env_enabled in paste_common._effective_guard and Config._load_env.
- Add tests/test_constants.py; fix env leakage in tests/test_config_refactor.py.

Result
- Consistent, centralized env boolean parsing; all tests green locally.

Closes: #34
