### PR TITLE
Fix: Eliminate CTranslate2 float16 conversion warning (#51)

### DIFF
--- a/src/presstalk/engine/fwhisper_backend.py
+++ b/src/presstalk/engine/fwhisper_backend.py
@@ -48,6 +48,9 @@ class FasterWhisperBackend:
             kwargs["device"] = self._device
         if self._compute_type:
             kwargs["compute_type"] = self._compute_type
+        else:
+            # Default to float32 to avoid ctranslate2 warnings about float16 conversion
+            kwargs["compute_type"] = "float32"
             
         try:
             self._model = WhisperModel(self._model_name, **kwargs)


### PR DESCRIPTION
## Summary

Eliminates the CTranslate2 warning that appears during model loading by explicitly setting the default compute type to float32.

## Problem

Users see this confusing warning during startup:


## Solution

- Set  as the default in  when not explicitly configured
- This prevents the automatic conversion and eliminates the warning
- No performance impact as the conversion was happening anyway

## Changes

- Modified  to default to float32 compute type
- Added logic to set compute_type when not specified by user

## Testing

- ✅ Warning no longer appears during model loading
- ✅ All functionality remains intact
- ✅ Console output is clean during startup

Closes #51