### PR TITLE
CLI config: unify hotkey editor; manual validation; single modifiers; drop record mode; preserve YAML comments

### DIFF
--- a/src/presstalk/beep.py
+++ b/src/presstalk/beep.py
@@ -26,4 +26,3 @@ def beep() -> None:
     except Exception:
         # swallow all
         pass
-

--- a/src/presstalk/cli.py
+++ b/src/presstalk/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import time
 import os
+import sys
 
 from . import __version__
 from .config import Config
@@ -14,7 +15,6 @@ from .hotkey import HotkeyHandler
 from .engine.dummy_engine import DummyAsrEngine
 from .logger import get_logger, QUIET, INFO, DEBUG
 from .logo import print_logo
-from .beep import beep as system_beep
 
 
 def _build_run_orchestrator(cfg: Config) -> Orchestrator:
@@ -211,7 +211,9 @@ def build_parser() -> argparse.ArgumentParser:
     # config subcommand
     cfgp = sub.add_parser("config", help="Interactive configuration editor")
     cfgp.add_argument("--config", help="Path to YAML config (presstalk.yaml)")
-    cfgp.add_argument("--show", action="store_true", help="Show current config and exit")
+    cfgp.add_argument(
+        "--show", action="store_true", help="Show current config and exit"
+    )
     return parser
 
 
@@ -369,10 +371,73 @@ def _write_yaml(path: str, data: dict) -> None:
         f.writelines(lines)
 
 
+def _write_yaml_preserve_comments(path: str, data: dict) -> None:
+    """Best-effort in-place YAML update that preserves comments and ordering.
+
+    Only updates top-level scalar keys present in `data` if their lines exist.
+    If a key is missing, it will be appended at the end (without comments).
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except Exception:
+        # Fallback to simple writer
+        return _write_yaml(path, data)
+
+    import re
+
+    updated = {k: False for k in data.keys()}
+
+    def _to_scalar(v) -> str:
+        if isinstance(v, bool):
+            return "true" if v else "false"
+        return str(v)
+
+    new_lines = []
+    for line in lines:
+        replaced = False
+        # skip pure comment lines
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            new_lines.append(line)
+            continue
+        for k, v in data.items():
+            # match: <indent>key : <value> [#comment]
+            # keep indentation and inline comments
+            pat = rf"^(\s*{re.escape(k)}\s*:\s*)([^#\n]*?)(\s*(#.*)?)$"
+            m = re.match(pat, line)
+            if m:
+                prefix, _old, suffix = m.group(1), m.group(2), m.group(3)
+                val = _to_scalar(v)
+                new_line = (
+                    f"{prefix}{val}{suffix}\n"
+                    if not line.endswith("\n")
+                    else f"{prefix}{val}{suffix}"
+                )
+                new_lines.append(new_line)
+                updated[k] = True
+                replaced = True
+                break
+        if not replaced:
+            new_lines.append(line)
+
+    # append missing keys at end
+    for k, v in data.items():
+        if not updated.get(k, False):
+            new_lines.append(f"{k}: {_to_scalar(v)}\n")
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(new_lines)
+
+
 def _run_config(args) -> int:
     cfg_path = _find_repo_config(getattr(args, "config", None))
     cfg = Config(config_path=cfg_path)
+    show_logo = bool(getattr(cfg, "show_logo", True))
+    logo_style = getattr(cfg, "logo_style", "simple")
     if getattr(args, "show", False):
+        if show_logo:
+            print_logo(use_color=True, style=logo_style)
         print("PressTalk Configuration (read-only)")
         print(f"Current hotkey: {cfg.hotkey}")
         print(f"Current language: {cfg.language}")
@@ -384,44 +449,363 @@ def _run_config(args) -> int:
     try:
         from .hotkey_pynput import validate_hotkey, normalize_hotkey
     except Exception:
-        def normalize_hotkey(x: str) -> str: return x
-        def validate_hotkey(x: str) -> bool: return bool(x)
 
-    def edit_hotkey() -> None:
-        cur = cfg.hotkey
-        for _ in range(2):
-            hk = input(
-                f"New hotkey (e.g., ctrl+space, ctrl+shift+x) [{cur}]: "
-            ).strip()
-            if not hk:
-                return
-            hk = normalize_hotkey(hk)
-            if validate_hotkey(hk):
-                cfg.hotkey = hk
-                return
-            print("Invalid hotkey; please try again or press Enter to keep current.")
+        def normalize_hotkey(x: str) -> str:
+            return x
+
+        def validate_hotkey(x: str) -> bool:
+            return bool(x)
+
+    def _read_line_with_esc(prompt: str) -> tuple[bool, str]:
+        """Read a line from TTY, returning (escaped, text).
+        - If ESC is pressed (without Enter), returns (True, '').
+        - Otherwise returns (False, the entered text without trailing newline).
+        In non-TTY environments, falls back to input().
+        """
+        try:
+            if os.name == "nt":
+                import msvcrt  # type: ignore
+
+                if not sys.stdin.isatty():
+                    s = input(prompt)
+                    return (False, s)
+                print(prompt, end="", flush=True)
+                buf: list[str] = []
+                while True:
+                    ch = msvcrt.getwch()
+                    # Arrow/function keys start with \xe0
+                    if ch == "\xe0":
+                        key2 = msvcrt.getwch()
+                        # Up/Down -> ignore; Left/Right -> cancel
+                        if key2 in ("H", "P"):  # up, down
+                            continue
+                        if key2 in ("K", "M"):  # left, right
+                            print()
+                            return (True, "")
+                        continue
+                    if ch == "\x1b":  # ESC
+                        print()
+                        return (True, "")
+                    if ch in ("\r", "\n"):
+                        print()
+                        return (False, "".join(buf))
+                    if ch in ("\b", "\x08"):
+                        if buf:
+                            buf.pop()
+                            # erase last char
+                            print("\b \b", end="", flush=True)
+                        continue
+                    buf.append(ch)
+                    print(ch, end="", flush=True)
+            else:
+                import tty
+                import termios
+
+                if not sys.stdin.isatty():
+                    s = input(prompt)
+                    return (False, s)
+                print(prompt, end="", flush=True)
+                fd = sys.stdin.fileno()
+                old = termios.tcgetattr(fd)
+                buf: list[str] = []
+                try:
+                    tty.setraw(fd)
+                    while True:
+                        ch = sys.stdin.read(1)
+                        if ch == "\x1b":  # ESC or ANSI sequence
+                            # Peek possible '[' for arrow sequence
+                            sys.stdin.flush()
+                            ch2 = sys.stdin.read(1)
+                            if ch2 == "[":
+                                ch3 = sys.stdin.read(1)
+                                # Up/Down: ignore; Left/Right: cancel
+                                if ch3 in ("A", "B"):  # up, down
+                                    continue
+                                if ch3 in ("C", "D"):  # right, left
+                                    print()
+                                    return (True, "")
+                                # Unknown sequence: ignore
+                                continue
+                            # Bare ESC: cancel
+                            print()
+                            return (True, "")
+                        if ch in ("\r", "\n"):
+                            print()
+                            return (False, "".join(buf))
+                        if ch == "\x7f":  # backspace
+                            if buf:
+                                buf.pop()
+                                print("\b \b", end="", flush=True)
+                            continue
+                        buf.append(ch)
+                        print(ch, end="", flush=True)
+                finally:
+                    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        except Exception:
+            # fallback
+            s = input(prompt)
+            return (False, s)
+
+    # Note: legacy 'record mode' hotkey editor has been removed in favor of unified list/manual UI.
 
     def edit_language() -> None:
         cur = cfg.language
-        lang = input(f"Language (en/ja/es/fr/de/...) [{cur}]: ").strip()
-        if lang:
-            cfg.language = lang
+        # Representative list + manual entry option
+        options = [
+            "en",
+            "ja",
+            "es",
+            "fr",
+            "de",
+            "it",
+            "pt",
+            "zh",
+            "ko",
+            "hi",
+            "ar",
+            "ru",
+            "other (type manually)",
+        ]
+        if sys.stdin.isatty():
+
+            def _clr():
+                try:
+                    if os.name == "nt":
+                        os.system("cls")
+                    else:
+                        print("\033[2J\033[H", end="")
+                except Exception:
+                    pass
+
+            def _key():
+                try:
+                    if os.name == "nt":
+                        import msvcrt  # type: ignore
+
+                        ch = msvcrt.getwch()
+                        if ch == "\xe0":
+                            ch2 = msvcrt.getwch()
+                            return ("win", ch2)
+                        return ("chr", ch)
+                    else:
+                        import tty
+                        import termios
+
+                        fd = sys.stdin.fileno()
+                        old = termios.tcgetattr(fd)
+                        try:
+                            tty.setraw(fd)
+                            ch1 = sys.stdin.read(1)
+                            if ch1 == "\x1b":
+                                ch2 = sys.stdin.read(1)
+                                if ch2 == "[":
+                                    ch3 = sys.stdin.read(1)
+                                    return ("ansi", ch3)
+                                return ("esc", None)
+                            return ("chr", ch1)
+                        finally:
+                            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+                except Exception:
+                    return ("chr", "\n")
+
+            # position cursor on current language if listed
+            try:
+                idx = options.index(cur)  # type: ignore[arg-type]
+            except Exception:
+                idx = 0
+            while True:
+                _clr()
+                if bool(getattr(cfg, "show_logo", True)):
+                    print_logo(
+                        use_color=True, style=getattr(cfg, "logo_style", "simple")
+                    )
+                print("Select Language (↑/↓ to move, Enter=Choose, ESC/←/→=Cancel)")
+                for i, name in enumerate(options):
+                    pointer = ">" if i == idx else " "
+                    star = "*" if name == cur else " "
+                    print(f" {pointer} {star} {name}")
+                kind, val = _key()
+                if kind == "ansi":
+                    if val == "A":
+                        idx = (idx - 1) % len(options)
+                        continue
+                    if val == "B":
+                        idx = (idx + 1) % len(options)
+                        continue
+                    if val in ("C", "D"):
+                        return
+                    continue
+                if kind == "win":
+                    if val == "H":
+                        idx = (idx - 1) % len(options)
+                        continue
+                    if val == "P":
+                        idx = (idx + 1) % len(options)
+                        continue
+                    if val in ("K", "M"):
+                        return
+                    continue
+                if kind == "esc":
+                    return
+                if kind == "chr":
+                    if val in ("\r", "\n"):
+                        if options[idx].startswith("other"):
+                            # manual entry prompt
+                            esc2, lang2 = _read_line_with_esc(
+                                f"Language code (e.g., en/ja) [{cur}] (ESC to cancel, Enter to keep): "
+                            )
+                            lang2 = lang2.strip()
+                            if esc2:
+                                return
+                            if not lang2:
+                                return
+                            cfg.language = lang2
+                            return
+                        else:
+                            cfg.language = options[idx]
+                            return
+                    if val.isdigit():
+                        d = int(val)
+                        if 1 <= d <= len(options):
+                            if options[d - 1].startswith("other"):
+                                esc2, lang2 = _read_line_with_esc(
+                                    f"Language code (e.g., en/ja) [{cur}] (ESC to cancel, Enter to keep): "
+                                )
+                                lang2 = lang2.strip()
+                                if esc2:
+                                    return
+                                if not lang2:
+                                    return
+                                cfg.language = lang2
+                                return
+                            cfg.language = options[d - 1]
+                            return
+                    continue
+        else:
+            esc, lang = _read_line_with_esc(
+                f"Language (en/ja/es/fr/de/...) [{cur}] (ESC to cancel, Enter to keep): "
+            )
+            lang = lang.strip()
+            if esc or lang.lower() == "esc":
+                return
+            if lang:
+                cfg.language = lang
 
     def edit_model() -> None:
         cur_model = cfg.model or "small"
-        allowed = {"tiny", "base", "small", "medium", "large"}
-        m = input(f"Model (tiny/base/small/medium/large) [{cur_model}]: ").strip().lower()
-        if m:
-            if m in allowed:
-                cfg.model = m
-            else:
-                print("Invalid model; keeping current.")
+        options = ["tiny", "base", "small", "medium", "large"]
+        # TTY: arrow selection; non-TTY: fallback to line input
+        if sys.stdin.isatty():
+            # simple screen clear
+            def _clr():
+                try:
+                    if os.name == "nt":
+                        os.system("cls")
+                    else:
+                        print("\033[2J\033[H", end="")
+                except Exception:
+                    pass
+
+            def _key():
+                try:
+                    if os.name == "nt":
+                        import msvcrt  # type: ignore
+
+                        ch = msvcrt.getwch()
+                        if ch == "\xe0":
+                            ch2 = msvcrt.getwch()
+                            return ("win", ch2)
+                        return ("chr", ch)
+                    else:
+                        import tty
+                        import termios
+
+                        fd = sys.stdin.fileno()
+                        old = termios.tcgetattr(fd)
+                        try:
+                            tty.setraw(fd)
+                            ch1 = sys.stdin.read(1)
+                            if ch1 == "\x1b":
+                                ch2 = sys.stdin.read(1)
+                                if ch2 == "[":
+                                    ch3 = sys.stdin.read(1)
+                                    return ("ansi", ch3)
+                                return ("esc", None)
+                            return ("chr", ch1)
+                        finally:
+                            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+                except Exception:
+                    return ("chr", "\n")
+
+            idx = options.index(cur_model) if cur_model in options else 0
+            while True:
+                _clr()
+                if bool(getattr(cfg, "show_logo", True)):
+                    print_logo(
+                        use_color=True, style=getattr(cfg, "logo_style", "simple")
+                    )
+                print("Select Model (↑/↓ to move, Enter=Choose, ESC/←/→=Cancel)")
+                for i, name in enumerate(options):
+                    pointer = ">" if i == idx else " "
+                    star = "*" if name == cur_model else " "
+                    print(f" {pointer} {star} {name}")
+                kind, val = _key()
+                if kind == "ansi":
+                    if val == "A":  # up
+                        idx = (idx - 1) % len(options)
+                        continue
+                    if val == "B":  # down
+                        idx = (idx + 1) % len(options)
+                        continue
+                    if val in ("C", "D"):  # right/left => cancel
+                        return
+                    continue
+                if kind == "win":
+                    if val == "H":  # up
+                        idx = (idx - 1) % len(options)
+                        continue
+                    if val == "P":  # down
+                        idx = (idx + 1) % len(options)
+                        continue
+                    if val in ("K", "M"):  # left/right => cancel
+                        return
+                    continue
+                if kind == "esc":
+                    return
+                if kind == "chr":
+                    if val in ("\r", "\n"):
+                        cfg.model = options[idx]
+                        return
+                    # digits quick select 1..len
+                    if val.isdigit():
+                        d = int(val)
+                        if 1 <= d <= len(options):
+                            cfg.model = options[d - 1]
+                            return
+                    # other keys ignored
+                    continue
+        else:
+            allowed = set(options)
+            esc, m = _read_line_with_esc(
+                f"Model (tiny/base/small/medium/large) [{cur_model}] (ESC to cancel, Enter to keep): "
+            )
+            m = m.strip().lower()
+            if esc or m == "esc":
+                return
+            if m:
+                if m in allowed:
+                    cfg.model = m
+                else:
+                    print("Invalid model; keeping current.")
 
     def edit_audio() -> None:
         cur = bool(getattr(cfg, "audio_feedback", True))
-        ans = input(
-            f"Enable audio feedback? [{'Y' if cur else 'y'}/{'n' if cur else 'N'}]: "
-        ).strip().lower()
+        esc, ans = _read_line_with_esc(
+            f"Enable audio feedback? [{'Y' if cur else 'y'}/{'n' if cur else 'N'}] (ESC to cancel, Enter to keep): "
+        )
+        ans = ans.strip().lower()
+        if esc or ans == "esc":
+            return
         if ans in ("y", "yes"):
             cfg.audio_feedback = True
         elif ans in ("n", "no"):
@@ -433,21 +817,195 @@ def _run_config(args) -> int:
             pkg_dir = os.path.dirname(__file__)
             repo_root = os.path.abspath(os.path.join(pkg_dir, "..", ".."))
             path = os.path.join(repo_root, "presstalk.yaml")
+        # Confirm before writing
+        esc, ans = _read_line_with_esc(f"Save changes to {path}? [Y/n] (Enter=Yes): ")
+        ans = ans.strip().lower()
+        # Default is Yes: Enter == Yes
+        if esc or ans in ("n", "no"):
+            print("Canceled. Not saved.")
+            return 1
         data = {
             "language": cfg.language,
             "model": cfg.model,
             "hotkey": cfg.hotkey,
             "audio_feedback": bool(getattr(cfg, "audio_feedback", True)),
         }
-        _write_yaml(path, data)
+        # Preserve comments when possible
+        _write_yaml_preserve_comments(path, data)
         print(f"Configuration saved to {path}")
         return 0
+
+    def _edit_hotkey_list() -> None:
+        cur = cfg.hotkey
+        options = [
+            "ctrl+space",
+            "ctrl+shift",
+            "ctrl+shift+space",
+            "other (type manually)",
+        ]
+
+        # Manual prompt helper with validation + retry
+        def _prompt_hotkey_manual(current: str) -> None:
+            while True:
+                esc, hk = _read_line_with_esc(
+                    f"New hotkey (e.g., x, space, ctrl, ctrl+shift+space) [{current}] (ESC to cancel, Enter to keep): "
+                )
+                hk = hk.strip()
+                if esc or not hk:
+                    return
+                hkn = normalize_hotkey(hk)
+                if validate_hotkey(hkn):
+                    cfg.hotkey = hkn
+                    return
+                print(
+                    "Invalid hotkey; please try again or press Enter to keep current."
+                )
+
+        if sys.stdin.isatty():
+
+            def _clr():
+                try:
+                    if os.name == "nt":
+                        os.system("cls")
+                    else:
+                        print("\033[2J\033[H", end="")
+                except Exception:
+                    pass
+
+            def _key():
+                try:
+                    if os.name == "nt":
+                        import msvcrt  # type: ignore
+
+                        ch = msvcrt.getwch()
+                        if ch == "\xe0":
+                            ch2 = msvcrt.getwch()
+                            return ("win", ch2)
+                        return ("chr", ch)
+                    else:
+                        import tty
+                        import termios
+
+                        fd = sys.stdin.fileno()
+                        old = termios.tcgetattr(fd)
+                        try:
+                            tty.setraw(fd)
+                            ch1 = sys.stdin.read(1)
+                            if ch1 == "\x1b":
+                                ch2 = sys.stdin.read(1)
+                                if ch2 == "[":
+                                    ch3 = sys.stdin.read(1)
+                                    return ("ansi", ch3)
+                                return ("esc", None)
+                            return ("chr", ch1)
+                        finally:
+                            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+                except Exception:
+                    return ("chr", "\n")
+
+            try:
+                idx = options.index(cur)
+            except Exception:
+                idx = 0
+            while True:
+                _clr()
+                if bool(getattr(cfg, "show_logo", True)):
+                    print_logo(
+                        use_color=True, style=getattr(cfg, "logo_style", "simple")
+                    )
+                print("Select Hotkey (↑/↓ to move, Enter=Choose, ESC/←/→=Cancel)")
+                for i, name in enumerate(options):
+                    pointer = ">" if i == idx else " "
+                    star = "*" if name == cur else " "
+                    print(f" {pointer} {star} {name}")
+                kind, val = _key()
+                if kind == "ansi":
+                    if val == "A":
+                        idx = (idx - 1) % len(options)
+                        continue
+                    if val == "B":
+                        idx = (idx + 1) % len(options)
+                        continue
+                    if val in ("C", "D"):
+                        return
+                    continue
+                if kind == "win":
+                    if val == "H":
+                        idx = (idx - 1) % len(options)
+                        continue
+                    if val == "P":
+                        idx = (idx + 1) % len(options)
+                        continue
+                    if val in ("K", "M"):
+                        return
+                    continue
+                if kind == "esc":
+                    return
+                if kind == "chr":
+                    if val in ("\r", "\n"):
+                        choice = options[idx]
+                        if choice.startswith("other"):
+                            _prompt_hotkey_manual(cur)
+                            return
+                        else:
+                            if validate_hotkey(choice):
+                                cfg.hotkey = choice
+                            return
+                    if val.isdigit():
+                        d = int(val)
+                        if 1 <= d <= len(options):
+                            choice = options[d - 1]
+                            if choice.startswith("other"):
+                                _prompt_hotkey_manual(cur)
+                                return
+                            else:
+                                if validate_hotkey(choice):
+                                    cfg.hotkey = choice
+                                return
+                    continue
+        else:
+            # Simple numbered list in non-TTY environments
+            while True:
+                print("Select Hotkey (type 1-4, Enter=keep current, or type a combo)")
+                for i, name in enumerate(options, start=1):
+                    star = "*" if name == cur else " "
+                    print(f"  {i}) {name} {star}")
+                sel = input("Select [1-4 or combo]: ").strip()
+                if not sel:
+                    return
+                if sel.isdigit():
+                    d = int(sel)
+                    if 1 <= d <= len(options):
+                        choice = options[d - 1]
+                        if choice.startswith("other"):
+                            _prompt_hotkey_manual(cur)
+                            return
+                        if validate_hotkey(choice):
+                            cfg.hotkey = choice
+                            return
+                        print(
+                            "Invalid hotkey; try again or press Enter to keep current."
+                        )
+                        continue
+                    print("Invalid selection; try again.")
+                    continue
+                # treat as direct text input
+                hkn = normalize_hotkey(sel)
+                if validate_hotkey(hkn):
+                    cfg.hotkey = hkn
+                    return
+                print("Invalid hotkey; try again.")
+                continue
 
     # simple (numbered) menu for accessibility and testability
     simple = os.getenv("PT_SIMPLE_UI") == "1" or not sys.stdin.isatty()
     if simple:
+        if show_logo:
+            print_logo(use_color=True, style=logo_style)
         while True:
             print("PressTalk Configuration")
+            print("- Type 1-6 then Enter to select. Ctrl+C to cancel.")
+            print("- In editors: press Enter with no input to keep current value.")
             print(f"  1) Hotkey: {cfg.hotkey}")
             print(f"  2) Language: {cfg.language}")
             print(f"  3) Model: {cfg.model}")
@@ -456,7 +1014,7 @@ def _run_config(args) -> int:
             print("  6) Quit (discard)")
             sel = input("Select [1-6]: ").strip()
             if sel == "1":
-                edit_hotkey()
+                _edit_hotkey_list()
             elif sel == "2":
                 edit_language()
             elif sel == "3":
@@ -464,7 +1022,10 @@ def _run_config(args) -> int:
             elif sel == "4":
                 edit_audio()
             elif sel == "5":
-                return save_and_exit()
+                rc = save_and_exit()
+                if rc == 0:
+                    return 0
+                # else back to menu
             elif sel == "6":
                 print("Aborted. No changes saved.")
                 return 0
@@ -473,7 +1034,7 @@ def _run_config(args) -> int:
     else:
         # Arrow-key interactive menu (TTY)
         items = [
-            ("Hotkey", edit_hotkey),
+            ("Hotkey", _edit_hotkey_list),
             ("Language", edit_language),
             ("Model", edit_model),
             ("Audio feedback", edit_audio),
@@ -481,8 +1042,21 @@ def _run_config(args) -> int:
             ("Quit (discard)", None),
         ]
 
+        def _clear_screen() -> None:
+            try:
+                if sys.stdout.isatty():
+                    if os.name == "nt":
+                        os.system("cls")
+                    else:
+                        # ANSI clear + home
+                        print("\033[2J\033[H", end="")
+            except Exception:
+                pass
+
         def _render(idx: int) -> None:
-            # Clear screen minimal: print separators for simplicity (no ANSI)
+            _clear_screen()
+            if show_logo:
+                print_logo(use_color=True, style=logo_style)
             print("PressTalk Configuration")
             for i, (label, _) in enumerate(items, start=1):
                 pointer = ">" if (i - 1) == idx else " "
@@ -490,25 +1064,35 @@ def _run_config(args) -> int:
                     0: cfg.hotkey,
                     1: cfg.language,
                     2: cfg.model,
-                    3: str(getattr(cfg, 'audio_feedback', True)),
+                    3: str(getattr(cfg, "audio_feedback", True)),
                 }.get(i - 1, "")
                 if value:
                     print(f" {pointer} {i}) {label}: {value}")
                 else:
                     print(f" {pointer} {i}) {label}")
-            print("Use ↑/↓ or j/k to navigate, Enter to select, digits 1-6 for shortcut, q to quit.")
+            print(
+                "Use ↑/↓ or j/k to navigate, Enter to select, digits 1-6 for shortcut, q to quit."
+            )
+            try:
+                sys.stdout.flush()
+            except Exception:
+                pass
 
         def _get_key():
             import sys
+
             try:
                 import msvcrt  # type: ignore
+
                 if msvcrt.kbhit():
                     ch = msvcrt.getch()
                 else:
                     ch = msvcrt.getch()
                 return ch
             except Exception:
-                import tty, termios
+                import tty
+                import termios
+
                 fd = sys.stdin.fileno()
                 old = termios.tcgetattr(fd)
                 try:
@@ -557,7 +1141,7 @@ def _run_config(args) -> int:
                 continue
 
             if sel == 1:
-                edit_hotkey()
+                _edit_hotkey_list()
             elif sel == 2:
                 edit_language()
             elif sel == 3:
@@ -565,7 +1149,10 @@ def _run_config(args) -> int:
             elif sel == 4:
                 edit_audio()
             elif sel == 5:
-                return save_and_exit()
+                rc = save_and_exit()
+                if rc == 0:
+                    return 0
+                # else back to menu
             elif sel == 6:
                 print("Aborted. No changes saved.")
                 return 0

--- a/src/presstalk/hotkey_pynput.py
+++ b/src/presstalk/hotkey_pynput.py
@@ -65,7 +65,8 @@ def validate_hotkey(spec: str) -> bool:
 
     Rules:
     - Allow one non-modifier key optionally combined with modifiers.
-    - Disallow modifier-only specs (e.g., "ctrl", "ctrl+alt").
+    - Allow a single modifier key by itself (e.g., "ctrl", "shift", "alt", "cmd").
+    - Disallow modifier-only specs with 2+ modifiers except the specific allowed set ("ctrl+shift").
     - Disallow empty specs.
     """
     norm = normalize_hotkey(spec)
@@ -86,7 +87,16 @@ def validate_hotkey(spec: str) -> bool:
             except Exception:
                 pass
         return True
-    # no primary: modifier-only is invalid
+    # no primary
+    if len(nonmods) == 0:
+        # single modifier only: allowed
+        if len(mods) == 1:
+            return True
+        # specific multi-modifier combos (e.g., ctrl+shift)
+        if len(mods) >= 2:
+            if set(mods) == {"ctrl", "shift"}:
+                return True
+            return False
     return False
 
 

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -116,6 +116,7 @@ class TestAudioFeedback(unittest.TestCase):
 
             def release(self) -> str:
                 import time
+
                 time.sleep(0.02)
                 calls.append("release_done")
                 return "ok"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -54,13 +54,14 @@ class TestCliConfig(unittest.TestCase):
             """
         )
         try:
-            # Provide new values and accept save
+            # Force simple menu; select items by number and provide new values
+            os.environ['PT_SIMPLE_UI'] = '1'
             inputs = [
-                "ctrl+shift+x",  # new hotkey
-                "en",            # language
-                "base",          # model
-                "n",             # audio feedback disabled
-                "y",             # save
+                "1", "ctrl+shift+x",  # edit hotkey
+                "2", "en",            # edit language
+                "3", "base",          # edit model
+                "4", "n",             # edit audio feedback (disable)
+                "5"                    # save changes
             ]
             args = SimpleNamespace(cmd="config", config=path, show=False)
             with mock.patch("builtins.input", side_effect=inputs):
@@ -73,19 +74,17 @@ class TestCliConfig(unittest.TestCase):
             self.assertEqual(cfg.model, "base")
             self.assertEqual(cfg.audio_feedback, False)
         finally:
+            os.environ.pop('PT_SIMPLE_UI', None)
             os.remove(path)
 
     def test_invalid_hotkey_is_handled(self):
         path = self._tmp_yaml("language: ja\nmodel: small\nhotkey: ctrl+space\n")
         try:
+            os.environ['PT_SIMPLE_UI'] = '1'
             # invalid hotkey then empty to keep current, then save
             inputs = [
-                "ctrl+alt",  # invalid (no primary)
-                "",          # keep current
-                "",          # language keep
-                "",          # model keep
-                "",          # audio feedback keep default prompt
-                "y",         # save
+                "1", "ctrl+alt", "",  # hotkey editor: invalid then keep current
+                "5"                      # save
             ]
             args = SimpleNamespace(cmd="config", config=path, show=False)
             with mock.patch("builtins.input", side_effect=inputs):
@@ -94,9 +93,9 @@ class TestCliConfig(unittest.TestCase):
             cfg = Config(config_path=path)
             self.assertEqual(cfg.hotkey, "ctrl+space")  # unchanged
         finally:
+            os.environ.pop('PT_SIMPLE_UI', None)
             os.remove(path)
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,102 @@
+import io
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import presstalk.cli as cli  # type: ignore
+from presstalk.config import Config
+
+
+class TestCliConfig(unittest.TestCase):
+    def _tmp_yaml(self, content: str = "") -> str:
+        fd, path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(textwrap.dedent(content))
+        return path
+
+    def test_config_show_prints_values(self):
+        path = self._tmp_yaml(
+            """
+            language: en
+            model: base
+            hotkey: ctrl+space
+            audio_feedback: true
+            """
+        )
+        try:
+            args = SimpleNamespace(cmd="config", config=path, show=True)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                rc = cli._run_config(args)
+            out = buf.getvalue()
+            self.assertEqual(rc, 0)
+            self.assertIn("Current hotkey:", out)
+            self.assertIn("ctrl+space", out)
+            self.assertIn("language:", out)
+            self.assertIn("model:", out)
+            self.assertIn("audio feedback:", out.lower())
+        finally:
+            os.remove(path)
+
+    def test_config_interactive_updates_and_saves(self):
+        path = self._tmp_yaml(
+            """
+            language: ja
+            model: small
+            hotkey: ctrl+space
+            audio_feedback: true
+            """
+        )
+        try:
+            # Provide new values and accept save
+            inputs = [
+                "ctrl+shift+x",  # new hotkey
+                "en",            # language
+                "base",          # model
+                "n",             # audio feedback disabled
+                "y",             # save
+            ]
+            args = SimpleNamespace(cmd="config", config=path, show=False)
+            with mock.patch("builtins.input", side_effect=inputs):
+                rc = cli._run_config(args)
+            self.assertEqual(rc, 0)
+            # Reload and verify file has updated values
+            cfg = Config(config_path=path)
+            self.assertEqual(cfg.hotkey, "ctrl+shift+x")
+            self.assertEqual(cfg.language, "en")
+            self.assertEqual(cfg.model, "base")
+            self.assertEqual(cfg.audio_feedback, False)
+        finally:
+            os.remove(path)
+
+    def test_invalid_hotkey_is_handled(self):
+        path = self._tmp_yaml("language: ja\nmodel: small\nhotkey: ctrl+space\n")
+        try:
+            # invalid hotkey then empty to keep current, then save
+            inputs = [
+                "ctrl+alt",  # invalid (no primary)
+                "",          # keep current
+                "",          # language keep
+                "",          # model keep
+                "",          # audio feedback keep default prompt
+                "y",         # save
+            ]
+            args = SimpleNamespace(cmd="config", config=path, show=False)
+            with mock.patch("builtins.input", side_effect=inputs):
+                rc = cli._run_config(args)
+            self.assertEqual(rc, 0)
+            cfg = Config(config_path=path)
+            self.assertEqual(cfg.hotkey, "ctrl+space")  # unchanged
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -55,13 +55,18 @@ class TestCliConfig(unittest.TestCase):
         )
         try:
             # Force simple menu; select items by number and provide new values
-            os.environ['PT_SIMPLE_UI'] = '1'
+            os.environ["PT_SIMPLE_UI"] = "1"
             inputs = [
-                "1", "ctrl+shift+x",  # edit hotkey
-                "2", "en",            # edit language
-                "3", "base",          # edit model
-                "4", "n",             # edit audio feedback (disable)
-                "5"                    # save changes
+                "1",
+                "ctrl+shift+x",  # edit hotkey
+                "2",
+                "en",  # edit language
+                "3",
+                "base",  # edit model
+                "4",
+                "n",  # edit audio feedback (disable)
+                "5",
+                "y",  # save changes, then confirm with 'y'
             ]
             args = SimpleNamespace(cmd="config", config=path, show=False)
             with mock.patch("builtins.input", side_effect=inputs):
@@ -74,17 +79,20 @@ class TestCliConfig(unittest.TestCase):
             self.assertEqual(cfg.model, "base")
             self.assertEqual(cfg.audio_feedback, False)
         finally:
-            os.environ.pop('PT_SIMPLE_UI', None)
+            os.environ.pop("PT_SIMPLE_UI", None)
             os.remove(path)
 
     def test_invalid_hotkey_is_handled(self):
         path = self._tmp_yaml("language: ja\nmodel: small\nhotkey: ctrl+space\n")
         try:
-            os.environ['PT_SIMPLE_UI'] = '1'
+            os.environ["PT_SIMPLE_UI"] = "1"
             # invalid hotkey then empty to keep current, then save
             inputs = [
-                "1", "ctrl+alt", "",  # hotkey editor: invalid then keep current
-                "5"                      # save
+                "1",
+                "ctrl+alt",
+                "",  # hotkey editor: invalid then keep current
+                "5",
+                "y",  # save + confirm with 'y'
             ]
             args = SimpleNamespace(cmd="config", config=path, show=False)
             with mock.patch("builtins.input", side_effect=inputs):
@@ -93,7 +101,7 @@ class TestCliConfig(unittest.TestCase):
             cfg = Config(config_path=path)
             self.assertEqual(cfg.hotkey, "ctrl+space")  # unchanged
         finally:
-            os.environ.pop('PT_SIMPLE_UI', None)
+            os.environ.pop("PT_SIMPLE_UI", None)
             os.remove(path)
 
 

--- a/tests/test_hotkey_combo.py
+++ b/tests/test_hotkey_combo.py
@@ -49,15 +49,18 @@ class TestHotkeyCombo(unittest.TestCase):
         self.assertEqual(normalize_hotkey("Cmd+Option+V"), "cmd+alt+v")
         self.assertEqual(normalize_hotkey("SHIFT+SPACE"), "shift+space")
 
-    def test_validate_invalid_hotkeys(self):
+    def test_validate_hotkeys_rules(self):
         from presstalk.hotkey_pynput import validate_hotkey
 
-        # invalid: only modifiers with no primary
+        # invalid: only modifiers with 2+ modifiers and no primary
         self.assertFalse(validate_hotkey("ctrl+alt"))
         # invalid: empty
         self.assertFalse(validate_hotkey(""))
-        # invalid: legacy single modifier no longer accepted
-        self.assertFalse(validate_hotkey("ctrl"))
+        # valid: single modifier allowed
+        self.assertTrue(validate_hotkey("ctrl"))
+        self.assertTrue(validate_hotkey("shift"))
+        self.assertTrue(validate_hotkey("alt"))
+        self.assertTrue(validate_hotkey("cmd"))
         # valid single non-modifier
         self.assertTrue(validate_hotkey("space"))
 


### PR DESCRIPTION
Purpose
- Make configuration accessible and consistent via `presstalk config`.

Summary of changes
- Unify hotkey editor to arrow-list UI; highlight current with `*`; digits quick select (TTY).
- Keep numbered list in simple/non‑TTY UI; allow direct text entry too.
- Manual entry: normalize + validate; invalid input loops with clear message; empty=keep, ESC=cancel.
- Validation: allow single modifier hotkeys (ctrl/shift/alt/cmd); still disallow multi‑modifier only combos except ctrl+shift.
- Remove legacy record mode (pynput listener capture) from config flow.
- Preserve comments and ordering when saving YAML (update existing lines; append missing keys).
- Lint fixes.

Acceptance
- Meets interactive guidance, shows current values, validates input, accessible to screen readers (simple UI), saves YAML, `--show` prints current config.

Usage
- Interactive: `presstalk config`
- Read-only: `presstalk config --show`

Testing notes
- `make lint` => All checks passed.
- Unit tests (hotkey + CLI config) pass; task runner `uv run python task.py test` passes.
- Verified simple UI flow and TTY list flow locally.

Parent
- Part of #54 v1.0.0 release.
